### PR TITLE
hide mapping boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ WhichKey comes with the following defaults:
     width = { min = 20, max = 50 }, -- min and max width of the columns
     spacing = 3, -- spacing between columns
   },
+  hidden = { "<silent>", "<cmd>", "<Cmd>", "<CR>", "call", "lua", "^:", "^ "}, -- hide mapping boilerplate
   show_help = true -- show help message on the command line when the popup is visible
 }
 ```

--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -35,6 +35,7 @@ local defaults = {
     width = { min = 20, max = 50 }, -- min and max width of the columns
     spacing = 3, -- spacing between columns
   },
+  hidden = { "<silent>", "<cmd>", "<Cmd>", "<CR>", "^:", "^ ", "^call ", "^lua "}, -- hide mapping boilerplate
   show_help = true, -- show a help message in the command line for using WhichKey
 }
 

--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -49,7 +49,11 @@ function M.get_mappings(mode, prefix, buf)
       value.label = value.label:gsub("^%+", "")
       value.label = Config.options.icons.group .. value.label
     else
-      value.label = value.label or value.cmd
+      local clean_value_cmd = value.cmd
+      for i,v in ipairs(Config.options.hidden) do 
+        clean_value_cmd = clean_value_cmd:gsub(v, "")
+      end
+      value.label = value.label or clean_value_cmd
     end
     table.insert(tmp, value)
   end

--- a/lua/which-key/text.lua
+++ b/lua/which-key/text.lua
@@ -43,10 +43,6 @@ end
 function Text:set(row, col, str, group)
   str = str:gsub("[\n]", " ")
 
-  for i,v in ipairs(config.options.hidden) do 
-    str = str:gsub(v, "")
-  end
-
   -- extend lines if needed
   for i = 1, row, 1 do if not self.lines[i] then self.lines[i] = "" end end
 

--- a/lua/which-key/text.lua
+++ b/lua/which-key/text.lua
@@ -1,3 +1,5 @@
+local config = require("which-key.config")
+
 ---@class Text
 ---@field lines string[]
 ---@field hl Highlight[]
@@ -40,6 +42,10 @@ end
 
 function Text:set(row, col, str, group)
   str = str:gsub("[\n]", " ")
+
+  for i,v in ipairs(config.options.hidden) do 
+    str = str:gsub(v, "")
+  end
 
   -- extend lines if needed
   for i = 1, row, 1 do if not self.lines[i] then self.lines[i] = "" end end


### PR DESCRIPTION
The default view is a bit compact, and even after configurating it a bit wider, many longer strings are shortened to an illisible "...", which kind of defeats the purpose of which-keys...

(consider one of my own mapping : `nnoremap <silent> <leader>a <cmd>lua require('lspsaga.codeaction').code_action()<CR>`, not saying it's best pratice but many users' may look like this)

This should help a little bit, by removing the standard boilerplate cluttering the mappings.

Probably not an exhaustive list, but this should be 'safe', ie not remove any substring that is an important part to understanding what the mapping do