### PR TITLE
fix: get value of register '=' with getreg('=',1)

### DIFF
--- a/lua/which-key/plugins/registers.lua
+++ b/lua/which-key/plugins/registers.lua
@@ -32,7 +32,7 @@ function M.run(_trigger, _mode, _buf)
 
   for i = 1, #M.registers, 1 do
     local key = M.registers:sub(i, i)
-    local ok, value = pcall(vim.fn.getreg, key)
+    local ok, value = pcall(vim.fn.getreg, key, 1)
     if not ok then
       value = ""
     end


### PR DESCRIPTION
without the '1' the register gets evaluated and I get
'Vim(call):E474: Invalid argument'.

From vim documentation:
	getreg('=') returns the last evaluated value of the expression
	register.  (For use in maps.)
	getreg('=', 1) returns the expression itself, so that it can
	be restored with |setreg()|.  For other registers the extra
	argument is ignored, thus you can always give it.