### PR TITLE
add trigger for command-line mode in register plugin

### DIFF
--- a/lua/which-key/plugins/registers.lua
+++ b/lua/which-key/plugins/registers.lua
@@ -6,6 +6,7 @@ M.actions = {
   { trigger = '"', mode = "n" },
   { trigger = "@", mode = "n" },
   { trigger = "<c-r>", mode = "i" },
+  { trigger = "<c-r>", mode = "c" },
 }
 
 M.registers = '*+"-:.%/#=_abcdefghijklmnopqrstuvwxyz0123456789'


### PR DESCRIPTION
NeoVim has a keybinding for `<C-r>` in command-line mode, as seen in [vim index](https://neovim.io/doc/user/vimindex.html).

It'd be useful to see it shown when I run `:WhichKey '' c`:
![image](https://user-images.githubusercontent.com/52215742/124403744-cd11c180-dd05-11eb-8955-9dfb7724f33e.png)

and this is what I see when I run `:WhichKey '' i`:
![image](https://user-images.githubusercontent.com/52215742/124403785-00545080-dd06-11eb-8e18-b2442550175d.png)


Note: I added the additional keybinding information seen in the screenshots in my vim configuration.