### PR TITLE
fix: feed CTRL-O again if mode is niI, niR or niV

### DIFF
--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -17,9 +17,10 @@ M.buf = nil
 M.win = nil
 
 function M.is_valid()
-  return M.buf and vim.api.nvim_buf_is_valid(M.buf) and vim.api.nvim_buf_is_loaded(M.buf) and vim.api.nvim_win_is_valid(
-    M.win
-  )
+  return M.buf
+    and vim.api.nvim_buf_is_valid(M.buf)
+    and vim.api.nvim_buf_is_loaded(M.buf)
+    and vim.api.nvim_win_is_valid(M.win)
 end
 
 function M.show()
@@ -195,6 +196,12 @@ function M.execute(prefix, mode, buf)
   unhook(Keys.get_tree(mode).tree:path(prefix))
   if buf then
     unhook(Keys.get_tree(mode, buf).tree:path(prefix), buf)
+  end
+
+  -- feed CTRL-O again if called from CTRL-O
+  local real_mode = Util.get_mode()
+  if real_mode == "nii" or real_mode == "nir" or real_mode == "niv" then
+    vim.api.nvim_feedkeys(Util.t("<C-O>"), "n", false)
   end
 
   -- handle registers that were passed when opening the popup


### PR DESCRIPTION
This PR solve thes problem mentioned in #141 in insert, replace and visual replace mode. The problem still exists in select mode. (I have opened ~<https://github.com/neovim/neovim/pull/15185>~ ~<https://github.com/vim/vim/pull/8640>~ <https://github.com/neovim/neovim/pull/15213> for this.)

The formatting in `M.is_valid()` is done by stylua 0.10.0 (the latest version) using the `stylua.toml` in this repository.