### PR TITLE
fix: feed CTRL-O again if called from CTRL-O

### DIFF
--- a/lua/which-key/util.lua
+++ b/lua/which-key/util.lua
@@ -10,8 +10,10 @@ function M.count(tab)
 end
 
 function M.get_mode()
-  local ret = vim.api.nvim_get_mode()
-  return string.lower(ret.mode)
+  local mode = vim.api.nvim_get_mode().mode
+  mode = mode:gsub(M.t("<C-V>"), "v")
+  mode = mode:gsub(M.t("<C-S>"), "s")
+  return mode:lower()
 end
 
 function M.is_empty(tab)

--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -17,9 +17,10 @@ M.buf = nil
 M.win = nil
 
 function M.is_valid()
-  return M.buf and vim.api.nvim_buf_is_valid(M.buf) and vim.api.nvim_buf_is_loaded(M.buf) and vim.api.nvim_win_is_valid(
-    M.win
-  )
+  return M.buf
+    and vim.api.nvim_buf_is_valid(M.buf)
+    and vim.api.nvim_buf_is_loaded(M.buf)
+    and vim.api.nvim_win_is_valid(M.win)
 end
 
 function M.show()
@@ -195,6 +196,12 @@ function M.execute(prefix, mode, buf)
   unhook(Keys.get_tree(mode).tree:path(prefix))
   if buf then
     unhook(Keys.get_tree(mode, buf).tree:path(prefix), buf)
+  end
+
+  -- feed CTRL-O again if called from CTRL-O
+  local full_mode = Util.get_mode()
+  if full_mode == "nii" or full_mode == "nir" or full_mode == "niv" or full_mode == "vs" then
+    vim.api.nvim_feedkeys(Util.t("<C-O>"), "n", false)
   end
 
   -- handle registers that were passed when opening the popup


### PR DESCRIPTION
`CTRL-O` is fed again if mode is `niI`, `niR`, `niV`, `vs`, `Vs`, `CTRL-Vs`.

`vs`, `Vs`, `CTRL-Vs` have just been ported to Neovim (<https://github.com/neovim/neovim/pull/15213>).