### PR TITLE
Add delay option to macro key (#152)

### DIFF
--- a/lua/which-key/plugins/registers.lua
+++ b/lua/which-key/plugins/registers.lua
@@ -4,14 +4,16 @@ M.name = "registers"
 
 M.actions = {
   { trigger = '"', mode = "n" },
-  { trigger = "@", mode = "n" },
+  { trigger = "@", mode = "n", delay = true },
   { trigger = "<c-r>", mode = "i" },
   { trigger = "<c-r>", mode = "c" },
 }
 
 function M.setup(_wk, _config, options)
   for _, action in ipairs(M.actions) do
-    table.insert(options.triggers_nowait, action.trigger)
+    if not action.delay then
+      table.insert(options.triggers_nowait, action.trigger)
+    end
   end
 end
 


### PR DESCRIPTION
Popup window instantly when one repeatedly invoke macro is quite annoying. This patch adds an option to disable nowait for @.