### PR TITLE
Add option to configure scroll bindings inside the popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ WhichKey comes with the following defaults:
     separator = "➜", -- symbol used between a key and it's label
     group = "+", -- symbol prepended to a group
   },
+  popup_mappings = {
+    scroll_down = '<c-d>', -- binding to scroll down inside the popup
+    scroll_up = '<c-u>', -- binding to scroll up inside the popup
+  },
   window = {
     border = "none", -- none, single, double, shadow
     position = "bottom", -- bottom, top

--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -41,6 +41,10 @@ local defaults = {
     separator = "➜", -- symbol used between a key and it's label
     group = "+", -- symbol prepended to a group
   },
+  popup_mappings = {
+    scroll_down = '<c-d>', -- binding to scroll down inside the popup
+    scroll_up = '<c-u>', -- binding to scroll up inside the popup
+  },
   window = {
     border = "none", -- none, single, double, shadow
     position = "bottom", -- bottom, top

--- a/lua/which-key/layout.lua
+++ b/lua/which-key/layout.lua
@@ -69,8 +69,8 @@ function Layout:trail()
     ["<esc>"] = "close",
   }
   if #self.text.lines > self.options.layout.height.max then
-    help["<c-d>"] = "scroll down"
-    help["<c-u>"] = "scroll up"
+    help[Config.options.popup_mappings.scroll_down] = "scroll down"
+    help[Config.options.popup_mappings.scroll_up] = "scroll up"
   end
   local help_line = {}
   local help_width = 0

--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -283,9 +283,9 @@ function M.on_keys(opts)
     if c == Util.t("<esc>") then
       M.on_close()
       break
-    elseif c == Util.t("<c-d>") then
+    elseif c == Util.t(config.options.popup_mappings.scroll_down) then
       M.scroll(false)
-    elseif c == Util.t("<c-u>") then
+    elseif c == Util.t(config.options.popup_mappings.scroll_up) then
       M.scroll(true)
     elseif c == Util.t("<bs>") then
       M.back()


### PR DESCRIPTION
Currently it's not possible to use `<c-d>` and `<c-u>` when defining keychords since which-key uses them to scroll up and down inside the popup. This just adds the option to change the default scrolling bindings during `setup`.