### PR TITLE
feat: Allow mapped lua functions to have arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ wk.register({
     e = "Edit File", -- same as above
     ["1"] = "which_key_ignore",  -- special label to hide it in the popup
     b = { function() print("bar") end, "Foobar" } -- you can also pass functions!
+    c = { require"telescope.builtin".find_files, args = { require"telescope.themes".get_ivy() }, "Find file, but with ivy-theme" } -- pass arguments to lua functions via args as an array
   },
 }, { prefix = "<leader>" })
 ```

--- a/lua/which-key/init.lua
+++ b/lua/which-key/init.lua
@@ -25,8 +25,8 @@ function M.setup(options)
 end
 
 function M.execute(id)
-  local func = Keys.functions[id]
-  return func()
+  local map = Keys.functions[id]
+  return map.func(unpack(map.args))
 end
 
 function M.show(keys, opts)

--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -205,12 +205,15 @@ function M.parse_mappings(mappings, value, prefix)
         elseif k == "plugin" then
           mapping.group = true
           mapping.plugin = v
+		elseif k == "args" then
+          mapping.args = v
         else
           error("Invalid key mapping: " .. vim.inspect(value))
         end
       end
       if mapping.cmd and type(mapping.cmd) == "function" then
-        table.insert(M.functions, mapping.cmd)
+        table.insert(M.functions, { func = mapping.cmd, args = mapping.args or {} })
+		mapping.args = nil
         if mapping.opts.expr then
           mapping.cmd = string.format([[luaeval('require("which-key").execute(%d)')]], #M.functions)
         else

--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -205,7 +205,7 @@ function M.parse_mappings(mappings, value, prefix)
         elseif k == "plugin" then
           mapping.group = true
           mapping.plugin = v
-		elseif k == "args" then
+        elseif k == "args" then
           mapping.args = v
         else
           error("Invalid key mapping: " .. vim.inspect(value))
@@ -213,7 +213,7 @@ function M.parse_mappings(mappings, value, prefix)
       end
       if mapping.cmd and type(mapping.cmd) == "function" then
         table.insert(M.functions, { func = mapping.cmd, args = mapping.args or {} })
-		mapping.args = nil
+        mapping.args = nil
         if mapping.opts.expr then
           mapping.cmd = string.format([[luaeval('require("which-key").execute(%d)')]], #M.functions)
         else


### PR DESCRIPTION
With a lot of lua plugins it is quite common to have bindings that call a lua function which can take some additional options. It would be nice if these arguments could be stored together with the function. Then upon invoking the mapping, the arguments could be unpacked and forwarded to the function. I think having an option called `args` that holds the arguments as an array would be a nice improvement.

One could then do
```
["<Leader>ff"] = { require"telescope.builtin".find_files, args = { require"telescope.themes".get_ivy() }, "Find files, but with ivy-theme" }
```
instead of
```
["<Leader>ff"] = { function() require"telescope.builtin".find_files(require"telescope.themes".get_ivy()) end, "Find files, but with ivy-theme" }
```