### PR TITLE
Make marks and registers plugin respect timeoutlen

### DIFF
--- a/lua/which-key/plugins/marks.lua
+++ b/lua/which-key/plugins/marks.lua
@@ -3,15 +3,17 @@ local M = {}
 M.name = "marks"
 
 M.actions = {
-  { trigger = "`", mode = "n" },
-  { trigger = "'", mode = "n" },
+  { trigger = "`", mode = "n", delay = true },
+  { trigger = "'", mode = "n", delay = true },
   { trigger = "g`", mode = "n" },
   { trigger = "g'", mode = "n" },
 }
 
 function M.setup(_wk, _config, options)
   for _, action in ipairs(M.actions) do
-    table.insert(options.triggers_nowait, action.trigger)
+    if not action.delay then
+      table.insert(options.triggers_nowait, action.trigger)
+    end
   end
 end
 

--- a/lua/which-key/plugins/registers.lua
+++ b/lua/which-key/plugins/registers.lua
@@ -3,7 +3,7 @@ local M = {}
 M.name = "registers"
 
 M.actions = {
-  { trigger = '"', mode = "n" },
+  { trigger = '"', mode = "n", delay = true },
   { trigger = "@", mode = "n", delay = true },
   { trigger = "<c-r>", mode = "i" },
   { trigger = "<c-r>", mode = "c" },


### PR DESCRIPTION
Make the popup window does not appear instantly when pressing `@`,`"`,``` ` ```, or ` ' `.

The same modification as in #156 done to the other triggers in _**marks.lua**_ and **_registers.lua_**.