### PR TITLE
Handle nvim_{buf_}get_keymap return no rhs due to 'callback' mapping

### DIFF
--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -524,16 +524,21 @@ function M.update_keymaps(mode, buf)
   ---@type Keymap
   local keymaps = buf and vim.api.nvim_buf_get_keymap(buf, mode) or vim.api.nvim_get_keymap(mode)
   local tree = M.get_tree(mode, buf).tree
+
+  local function is_no_op(keymap)
+    return not keymap.callback and Util.t(keymap.rhs) == ""
+  end
+
   for _, keymap in pairs(keymaps) do
     local skip = M.is_hook(keymap.lhs, keymap.rhs)
 
-    if not skip and Util.t(keymap.rhs) == "" then
+    if is_no_op(keymap) then
       skip = true
     end
 
     -- check if <leader> was remapped
     if not skip and Util.t(keymap.lhs) == Util.t("<leader>") and mode == "n" then
-      if Util.t(keymap.rhs) == "" then
+      if is_no_op(keymap) then
         skip = true
       else
         Util.warn(

--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -248,7 +248,7 @@ M.mappings = {}
 M.duplicates = {}
 
 function M.map(mode, prefix, cmd, buf, opts)
-  local other = vim.api.nvim_buf_call(buf, function()
+  local other = vim.api.nvim_buf_call(buf or 0, function()
     local ret = vim.fn.maparg(prefix, mode, false, true)
     ---@diagnostic disable-next-line: undefined-field
     return (ret and ret.lhs and ret.rhs ~= cmd) and ret or nil


### PR DESCRIPTION
This is the only issue I've run into when using the new `nvim_{buf_}set_keymap` functions added recently. Not sure if there is a cleaner way to fix it, but essentially we can no longer rely on the mappings having a `rhs` (as returned from `nvim_{buf_}get_keymap`) if they instead define a `callback` as part of the `opts` key.

This is the only place where I can see that this API function is used.

Fixes #224