### PR TITLE
Do not pass nil as an argument to nvim_buf_call

### DIFF
--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -248,7 +248,7 @@ M.mappings = {}
 M.duplicates = {}
 
 function M.map(mode, prefix, cmd, buf, opts)
-  local other = vim.api.nvim_buf_call(buf, function()
+  local other = vim.api.nvim_buf_call(buf or 0, function()
     local ret = vim.fn.maparg(prefix, mode, false, true)
     ---@diagnostic disable-next-line: undefined-field
     return (ret and ret.lhs and ret.rhs ~= cmd) and ret or nil


### PR DESCRIPTION
There is a breaking change in neovim 0.7.0 where the `buf` argument for `nvim_buf_call` API no longer allows implicit conversion from `nil`. 

To avoid an error, we need to explictly convert the argument to 0 to correctly denote the current buffer.

References:
https://github.com/neovim/neovim/issues/14090#issuecomment-1004318147
