### PR TITLE
feat: Use vim.keymap.set to allow lua mappings

### DIFF
--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -248,7 +248,7 @@ M.mappings = {}
 M.duplicates = {}
 
 function M.map(mode, prefix, cmd, buf, opts)
-  local other = vim.api.nvim_buf_call(buf, function()
+  local other = vim.api.nvim_buf_call(buf or 0, function()
     local ret = vim.fn.maparg(prefix, mode, false, true)
     ---@diagnostic disable-next-line: undefined-field
     return (ret and ret.lhs and ret.rhs ~= cmd) and ret or nil

--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -260,7 +260,7 @@ function M.map(mode, prefix, cmd, buf, opts)
   if buf ~= nil then
     pcall(vim.api.nvim_buf_set_keymap, buf, mode, prefix, cmd, opts)
   else
-    pcall(vim.api.nvim_set_keymap, mode, prefix, cmd, opts)
+    vim.keymap.set( mode, prefix, cmd, opts)
   end
 end
 

--- a/lua/which-key/util.lua
+++ b/lua/which-key/util.lua
@@ -21,6 +21,7 @@ function M.is_empty(tab)
 end
 
 function M.t(str)
+  if type(str)~="string" then return end
   return vim.api.nvim_replace_termcodes(str, true, true, true)
 end
 


### PR DESCRIPTION
This allows mappings like
`function() require('configs.telescope').grep_last_search() end`
instead of
`"<cmd>lua require('configs.telescope').grep_last_search()<CR>"`

but the old syntax still works

see `:h vim.keymap.set` for more examples