### PR TITLE
Reset `+` and `*` to default register when clipboard is set

### DIFF
--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -236,6 +236,14 @@ function M.open(keys, opts)
   M.count = vim.api.nvim_get_vvar("count")
   M.reg = vim.api.nvim_get_vvar("register")
 
+  if string.find(vim.o.clipboard, "unnamedplus") and M.reg == "+" then
+    M.reg = '"'
+  end
+
+  if string.find(vim.o.clipboard, "unnamed") and M.reg == "*" then
+    M.reg = '"'
+  end
+
   M.show_cursor()
   M.on_keys(opts)
 end


### PR DESCRIPTION
Fix https://github.com/folke/which-key.nvim/issues/202

Please let me know if there is anything I can do/add to the PR to help out. Love this plugin, thanks in advance!