### PR TITLE
Point all links in README to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,9 +246,9 @@ wk.register({
   + see [here](https://github.com/folke/which-key.nvim/blob/main/lua/which-key/plugins/presets/init.lua#L5) for the full list part of the preset
 * text objects are automatically retrieved from **operator pending** key maps (`omap`)
   + set `plugins.presets.text_objects` to `true` to configure built-in text objects
-  + see [here](https://github.com/folke/which-key.nvim/blob/423a50cccfeb8b812e0e89f156316a4bd9d2673a/lua/which-key/plugins/presets/init.lua#L43)
+  + see [here](https://github.com/folke/which-key.nvim/blob/main/lua/which-key/plugins/presets/init.lua#L43)
 * motions are part of the preset `plugins.presets.motions` setting
-  + see [here](https://github.com/folke/which-key.nvim/blob/423a50cccfeb8b812e0e89f156316a4bd9d2673a/lua/which-key/plugins/presets/init.lua#L20)
+  + see [here](https://github.com/folke/which-key.nvim/blob/main/lua/which-key/plugins/presets/init.lua#L20)
 
 <details>
 <summary>How to disable some operators? (like v)</summary>


### PR DESCRIPTION
Two links to sections of the source code seem to point to an (afaict) arbitrary commit, rather than to the main-branch version of the file. Another link to the same file _does_ point to the main-branch version of the file, which makes me think that this would be the intended state for all the links.
Thankfully the file didn't change much in the meantime, so the line-references are still accurate in either version.