### PR TITLE
feat: prefer `desc` to `cmd` as the fallback label

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Default options for `opts`
   mode = "n", -- NORMAL mode
   -- prefix: use "<leader>f" for example for mapping everything related to finding files
   -- the prefix is prepended to every mapping part of `mappings`
-  prefix = "", 
+  prefix = "",
   buffer = nil, -- Global mappings. Specify a buffer number for buffer local mappings
   silent = true, -- use `silent` when creating keymaps
   noremap = true, -- use `noremap` when creating keymaps
@@ -233,6 +233,10 @@ wk.register({
 ```
 
 </details>
+
+**Tips:** The default label is `keymap.desc` or `keymap.rhs` or `""`,
+ `:h nvim_set_keymap()` to get more details about `desc` and `rhs`.
+
 
 ### 🚙 Operators, Motions and Text Objects
 

--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -128,7 +128,7 @@ function M.get_mappings(mode, prefix, buf)
         value.label = value.label:gsub("^%+", "")
         value.label = Config.options.icons.group .. value.label
       elseif not value.label then
-        value.label = value.cmd or ""
+        value.label = value.desc or value.cmd or ""
         for _, v in ipairs(Config.options.hidden) do
           value.label = value.label:gsub(v, "")
         end
@@ -521,7 +521,7 @@ end
 ---@param mode string
 ---@param buf number
 function M.update_keymaps(mode, buf)
-  ---@type Keymap
+  ---@type Keymap[]
   local keymaps = buf and vim.api.nvim_buf_get_keymap(buf, mode) or vim.api.nvim_get_keymap(mode)
   local tree = M.get_tree(mode, buf).tree
 
@@ -557,6 +557,7 @@ function M.update_keymaps(mode, buf)
         id = Util.t(keymap.lhs),
         prefix = keymap.lhs,
         cmd = keymap.rhs,
+        desc = keymap.desc,
         keys = Util.parse_keys(keymap.lhs),
       }
       -- don't include Plug keymaps

--- a/lua/which-key/types.lua
+++ b/lua/which-key/types.lua
@@ -13,6 +13,7 @@
 ---@field sid number
 ---@field silent number
 ---@field id string terminal codes for lhs
+---@field desc string
 local Keymap
 
 ---@class KeyCodes
@@ -32,6 +33,7 @@ local MappingOptions
 ---@field buf number
 ---@field group boolean
 ---@field label string
+---@field desc string
 ---@field prefix string
 ---@field cmd string
 ---@field opts MappingOptions


### PR DESCRIPTION
It obviously makes more sense to use the built-in description as the default label, which even eliminates a lot of repetition of `require('which-key').register ... `

