### PR TITLE
Fix prefix

### DIFF
--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -42,15 +42,15 @@ local defaults = {
     group = "+", -- symbol prepended to a group
   },
   popup_mappings = {
-    scroll_down = '<c-d>', -- binding to scroll down inside the popup
-    scroll_up = '<c-u>', -- binding to scroll up inside the popup
+    scroll_down = "<c-d>", -- binding to scroll down inside the popup
+    scroll_up = "<c-u>", -- binding to scroll up inside the popup
   },
   window = {
     border = "none", -- none, single, double, shadow
     position = "bottom", -- bottom, top
     margin = { 1, 0, 1, 0 }, -- extra window margin [top, right, bottom, left]
     padding = { 1, 2, 1, 2 }, -- extra window padding [top, right, bottom, left]
-    winblend = 0 -- value between 0-100 0 for fully opaque and 100 for fully transparent
+    winblend = 0, -- value between 0-100 0 for fully opaque and 100 for fully transparent
   },
   layout = {
     height = { min = 4, max = 25 }, -- min and max height of the columns

--- a/lua/which-key/init.lua
+++ b/lua/which-key/init.lua
@@ -37,9 +37,6 @@ function M.show(keys, opts)
 
   keys = keys or ""
 
-  -- mappings will pass <lt> as <, so change it back
-  keys = keys:gsub("[<]", "<lt>")
-
   opts.mode = opts.mode or Util.get_mode()
   local buf = vim.api.nvim_get_current_buf()
   -- make sure the trees exist for update

--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -31,26 +31,30 @@ function M.setup()
   M.register(mappings, { mode = "n", preset = true })
   M.register({ i = { name = "inside" }, a = { name = "around" } }, { mode = "v", preset = true })
   for mode, blacklist in pairs(Config.options.triggers_blacklist) do
-    for _, prefix in ipairs(blacklist) do
+    for _, prefix_n in ipairs(blacklist) do
       M.blacklist[mode] = M.blacklist[mode] or {}
-      M.blacklist[mode][prefix] = true
+      M.blacklist[mode][prefix_n] = true
     end
   end
 end
 
-function M.get_operator(prefix)
-  for op, _ in pairs(Config.options.operators) do
-    if prefix:sub(1, #op) == op then
-      return op
+function M.get_operator(prefix_i)
+  for op_n, _ in pairs(Config.options.operators) do
+    local op_i = Util.t(op_n)
+    if prefix_i:sub(1, #op_i) == op_i then
+      return op_i, op_n
     end
   end
 end
 
-function M.process_motions(ret, mode, prefix, buf)
-  local operator = mode == "v" and "" or M.get_operator(prefix)
-  if (mode == "n" or mode == "v") and operator then
-    local op_prefix = prefix:sub(#operator + 1)
-    local op_count = op_prefix:match("^(%d+)")
+function M.process_motions(ret, mode, prefix_i, buf)
+  local op_i, op_n = "", ""
+  if mode ~= "v" then
+    op_i, op_n = M.get_operator(prefix_i)
+  end
+  if (mode == "n" or mode == "v") and op_i then
+    local op_prefix_i = prefix_i:sub(#op_i + 1)
+    local op_count = op_prefix_i:match("^(%d+)")
     if op_count == "0" then
       op_count = nil
     end
@@ -58,18 +62,18 @@ function M.process_motions(ret, mode, prefix, buf)
       op_count = nil
     end
     if op_count then
-      op_prefix = op_prefix:sub(#op_count + 1)
+      op_prefix_i = op_prefix_i:sub(#op_count + 1)
     end
-    local op_results = M.get_mappings("o", op_prefix, buf)
+    local op_results = M.get_mappings("o", op_prefix_i, buf)
 
     if not ret.mapping and op_results.mapping then
       ret.mapping = op_results.mapping
-      ret.mapping.prefix = prefix
-      ret.keys = Util.parse_keys(ret.prefix)
+      ret.mapping.prefix = op_n .. (op_count or "") .. ret.mapping.prefix
+      ret.mapping.keys = Util.parse_keys(ret.mapping.prefix)
     end
 
     for _, mapping in pairs(op_results.mappings) do
-      mapping.prefix = operator .. (op_count or "") .. mapping.prefix
+      mapping.prefix = op_n .. (op_count or "") .. mapping.prefix
       mapping.keys = Util.parse_keys(mapping.prefix)
       table.insert(ret.mappings, mapping)
     end
@@ -77,17 +81,17 @@ function M.process_motions(ret, mode, prefix, buf)
 end
 
 ---@return MappingGroup
-function M.get_mappings(mode, prefix, buf)
+function M.get_mappings(mode, prefix_i, buf)
   ---@class MappingGroup
   ---@field mode string
-  ---@field prefix string
+  ---@field prefix_i string
   ---@field buf number
   ---@field mapping Mapping
   ---@field mappings VisualMapping[]
   local ret
-  ret = { mapping = nil, mappings = {}, mode = mode, buf = buf, prefix = prefix }
+  ret = { mapping = nil, mappings = {}, mode = mode, buf = buf, prefix_i = prefix_i }
 
-  local prefix_len = #Util.parse_keys(prefix).nvim
+  local prefix_len = #Util.parse_internal(prefix_i)
 
   ---@param node Node
   local function add(node)
@@ -104,17 +108,16 @@ function M.get_mappings(mode, prefix, buf)
   end
 
   local plugin_context = { buf = buf, mode = mode }
-  add(M.get_tree(mode).tree:get(prefix, nil, plugin_context))
-  add(M.get_tree(mode, buf).tree:get(prefix, nil, plugin_context))
+  add(M.get_tree(mode).tree:get(prefix_i, nil, plugin_context))
+  add(M.get_tree(mode, buf).tree:get(prefix_i, nil, plugin_context))
 
   -- Handle motions
-  M.process_motions(ret, mode, prefix, buf)
+  M.process_motions(ret, mode, prefix_i, buf)
 
   -- Fix labels
   local tmp = {}
   for _, value in pairs(ret.mappings) do
-    value.key = value.keys.nvim[prefix_len + 1]
-    value.key = vim.fn.strtrans(value.key)
+    value.key = value.keys.notation[prefix_len + 1]
     if Config.options.key_labels[value.key] then
       value.key = Config.options.key_labels[value.key]
     end
@@ -165,29 +168,29 @@ end
 
 ---@param mappings Mapping[]
 ---@return Mapping[]
-function M.parse_mappings(mappings, value, prefix)
-  prefix = prefix or ""
+function M.parse_mappings(mappings, value, prefix_n)
+  prefix_n = prefix_n or ""
   if type(value) == "string" then
-    table.insert(mappings, { prefix = prefix, label = value })
+    table.insert(mappings, { prefix = prefix_n, label = value })
   elseif type(value) == "table" then
     if #value == 0 then
       -- key group
       for k, v in pairs(value) do
         if k ~= "name" then
-          M.parse_mappings(mappings, v, prefix .. k)
+          M.parse_mappings(mappings, v, prefix_n .. k)
         end
       end
-      if prefix ~= "" then
+      if prefix_n ~= "" then
         if value.name then
           value.name = value.name:gsub("^%+", "")
         end
-        table.insert(mappings, { prefix = prefix, label = value.name, group = true })
+        table.insert(mappings, { prefix = prefix_n, label = value.name, group = true })
       end
     else
       -- key mapping
       ---@type Mapping
       local mapping
-      mapping = { prefix = prefix, opts = {}, buf = M.get_buf_option(value) }
+      mapping = { prefix = prefix_n, opts = {}, buf = M.get_buf_option(value) }
       for k, v in pairs(value) do
         if k == 1 then
           mapping.label = v
@@ -247,32 +250,32 @@ end
 M.mappings = {}
 M.duplicates = {}
 
-function M.map(mode, prefix, cmd, buf, opts)
+function M.map(mode, prefix_n, cmd, buf, opts)
   local other = vim.api.nvim_buf_call(buf or 0, function()
-    local ret = vim.fn.maparg(prefix, mode, false, true)
+    local ret = vim.fn.maparg(prefix_n, mode, false, true)
     ---@diagnostic disable-next-line: undefined-field
     return (ret and ret.lhs and ret.rhs ~= cmd) and ret or nil
   end)
   if other then
-    table.insert(M.duplicates, { mode = mode, prefix = prefix, cmd = cmd, buf = buf, other = other })
+    table.insert(M.duplicates, { mode = mode, prefix = prefix_n, cmd = cmd, buf = buf, other = other })
   end
   cmd = cmd:gsub("[\\]", "<bslash>")
   if buf ~= nil then
-    pcall(vim.api.nvim_buf_set_keymap, buf, mode, prefix, cmd, opts)
+    pcall(vim.api.nvim_buf_set_keymap, buf, mode, prefix_n, cmd, opts)
   else
-    pcall(vim.api.nvim_set_keymap, mode, prefix, cmd, opts)
+    pcall(vim.api.nvim_set_keymap, mode, prefix_n, cmd, opts)
   end
 end
 
 function M.register(mappings, opts)
   opts = opts or {}
 
-  local prefix = opts.prefix or ""
+  local prefix_n = opts.prefix or ""
   local mode = opts.mode or "n"
 
   opts.buffer = M.get_buf_option(opts)
 
-  mappings = M.parse_mappings({}, mappings, prefix)
+  mappings = M.parse_mappings({}, mappings, prefix_n)
 
   -- always create the root node for the mode, even if there's no mappings,
   -- to ensure we have at least a trigger hooked for non documented keymaps
@@ -306,41 +309,41 @@ end
 
 M.hooked = {}
 
-function M.hook_id(prefix, mode, buf)
-  return mode .. (buf or "") .. Util.t(prefix)
+function M.hook_id(prefix_n, mode, buf)
+  return mode .. (buf or "") .. Util.t(prefix_n)
 end
 
-function M.is_hooked(prefix, mode, buf)
-  return M.hooked[M.hook_id(prefix, mode, buf)]
+function M.is_hooked(prefix_n, mode, buf)
+  return M.hooked[M.hook_id(prefix_n, mode, buf)]
 end
 
-function M.hook_del(prefix, mode, buf)
-  local id = M.hook_id(prefix, mode, buf)
+function M.hook_del(prefix_n, mode, buf)
+  local id = M.hook_id(prefix_n, mode, buf)
   M.hooked[id] = nil
   if buf then
-    pcall(vim.api.nvim_buf_del_keymap, buf, mode, prefix)
-    pcall(vim.api.nvim_buf_del_keymap, buf, mode, prefix .. secret)
+    pcall(vim.api.nvim_buf_del_keymap, buf, mode, prefix_n)
+    pcall(vim.api.nvim_buf_del_keymap, buf, mode, prefix_n .. secret)
   else
-    pcall(vim.api.nvim_del_keymap, mode, prefix)
-    pcall(vim.api.nvim_del_keymap, mode, prefix .. secret)
+    pcall(vim.api.nvim_del_keymap, mode, prefix_n)
+    pcall(vim.api.nvim_del_keymap, mode, prefix_n .. secret)
   end
 end
 
-function M.hook_add(prefix, mode, buf, secret_only)
+function M.hook_add(prefix_n, mode, buf, secret_only)
   -- check if this trigger is blacklisted
-  if M.blacklist[mode] and M.blacklist[mode][prefix] then
+  if M.blacklist[mode] and M.blacklist[mode][prefix_n] then
     return
   end
   -- don't hook numbers. See #118
-  if tonumber(prefix) then
+  if tonumber(prefix_n) then
     return
   end
   -- don't hook to j or k in INSERT mode
-  if mode == "i" and (prefix == "j" or prefix == "k") then
+  if mode == "i" and (prefix_n == "j" or prefix_n == "k") then
     return
   end
   -- never hook q
-  if mode == "n" and prefix == "q" then
+  if mode == "n" and prefix_n == "q" then
     return
   end
   -- never hook into select mode
@@ -352,24 +355,24 @@ function M.hook_add(prefix, mode, buf, secret_only)
   if mode == "o" then
     return
   end
-  if prefix == Util.t("<esc>") then
+  if Util.t(prefix_n) == Util.t("<esc>") then
     return
   end
   -- never hook into operators in visual mode
-  if (mode == "v" or mode == "x") and M.operators[prefix] then
+  if (mode == "v" or mode == "x") and M.operators[prefix_n] then
     return
   end
 
   -- Check if we need to create the hook
   if type(Config.options.triggers) == "string" and Config.options.triggers ~= "auto" then
-    if Util.t(prefix) ~= Util.t(Config.options.triggers) then
+    if Util.t(prefix_n) ~= Util.t(Config.options.triggers) then
       return
     end
   end
   if type(Config.options.triggers) == "table" then
     local ok = false
     for _, trigger in pairs(Config.options.triggers) do
-      if Util.t(trigger) == Util.t(prefix) then
+      if Util.t(trigger) == Util.t(prefix_n) then
         ok = true
         break
       end
@@ -380,27 +383,27 @@ function M.hook_add(prefix, mode, buf, secret_only)
   end
 
   local opts = { noremap = true, silent = true }
-  local id = M.hook_id(prefix, mode, buf)
-  local id_global = M.hook_id(prefix, mode)
+  local id = M.hook_id(prefix_n, mode, buf)
+  local id_global = M.hook_id(prefix_n, mode)
   -- hook up if needed
   if not M.hooked[id] and not M.hooked[id_global] then
     local cmd = [[<cmd>lua require("which-key").show(%q, {mode = %q, auto = true})<cr>]]
     if vim.g.mapleader == "\\" or vim.g.mapleader == nil then
-      prefix = prefix:gsub("<[lL]eader>", "\\")
+      prefix_n = prefix_n:gsub("<[lL]eader>", "\\")
     end
     if vim.g.maplocalleader == "\\" or vim.g.maplocalleader == nil then
-      prefix = prefix:gsub("<[lL]ocalleader>", "\\")
+      prefix_n = prefix_n:gsub("<[lL]ocalleader>", "\\")
     end
-    cmd = string.format(cmd, prefix, mode)
+    cmd = string.format(cmd, Util.t(prefix_n), mode)
     -- map group triggers and nops
     -- nops are needed, so that WhichKey always respects timeoutlen
 
     local mapmode = mode == "v" and "x" or mode
     if secret_only ~= true then
-      M.map(mapmode, prefix, cmd, buf, opts)
+      M.map(mapmode, prefix_n, cmd, buf, opts)
     end
-    if not M.nowait[prefix] then
-      M.map(mapmode, prefix .. secret, "<nop>", buf, opts)
+    if not M.nowait[prefix_n] then
+      M.map(mapmode, prefix_n .. secret, "<nop>", buf, opts)
     end
 
     M.hooked[id] = true
@@ -426,11 +429,11 @@ end
 ---@param node Node
 function M.add_hooks(mode, buf, node, secret_only)
   if not node.mapping then
-    node.mapping = { prefix = node.prefix, group = true, keys = Util.parse_keys(node.prefix) }
+    node.mapping = { prefix = node.prefix_n, group = true, keys = Util.parse_keys(node.prefix_n) }
   end
-  if node.prefix ~= "" and node.mapping.group == true and not node.mapping.cmd then
+  if node.prefix_n ~= "" and node.mapping.group == true and not node.mapping.cmd then
     -- first non-cmd level, so create hook and make all decendents secret only
-    M.hook_add(node.prefix, mode, buf, secret_only)
+    M.hook_add(node.prefix_n, mode, buf, secret_only)
     secret_only = true
   end
   for _, child in pairs(node.children) do
@@ -471,7 +474,7 @@ function M.check_health()
         end
 
         local auto_prefix = not node.mapping or (node.mapping.group == true and not node.mapping.cmd)
-        if node.prefix ~= "" and count > 0 and not auto_prefix then
+        if node.prefix_i ~= "" and count > 0 and not auto_prefix then
           local msg = ("conflicting keymap exists for mode **%q**, lhs: **%q**"):format(tree.mode, node.mapping.prefix)
           vim.fn["health#report_warn"](msg)
           local cmd = node.mapping.cmd or " "
@@ -560,7 +563,7 @@ function M.update_keymaps(mode, buf)
         keys = Util.parse_keys(keymap.lhs),
       }
       -- don't include Plug keymaps
-      if mapping.keys.nvim[1]:lower() ~= "<plug>" then
+      if mapping.keys.notation[1]:lower() ~= "<plug>" then
         tree:add(mapping)
       end
     end

--- a/lua/which-key/layout.lua
+++ b/lua/which-key/layout.lua
@@ -38,17 +38,17 @@ function Layout:max_width(key)
 end
 
 function Layout:trail()
-  local prefix = self.results.prefix
-  local buf_path = Keys.get_tree(self.results.mode, self.results.buf).tree:path(prefix)
-  local path = Keys.get_tree(self.results.mode).tree:path(prefix)
-  local len = #self.results.mapping.keys.nvim
+  local prefix_i = self.results.prefix_i
+  local buf_path = Keys.get_tree(self.results.mode, self.results.buf).tree:path(prefix_i)
+  local path = Keys.get_tree(self.results.mode).tree:path(prefix_i)
+  local len = #self.results.mapping.keys.notation
   local cmd_line = { { " " } }
   for i = 1, len, 1 do
     local node = buf_path[i]
     if not (node and node.mapping and node.mapping.label) then
       node = path[i]
     end
-    local step = self.mapping.keys.nvim[i]
+    local step = self.mapping.keys.notation[i]
     if node and node.mapping and node.mapping.label then
       step = self.options.icons.group .. node.mapping.label
     end
@@ -56,7 +56,7 @@ function Layout:trail()
       step = Config.options.key_labels[step]
     end
     table.insert(cmd_line, { step, "WhichKeyGroup" })
-    if i ~= #self.mapping.keys.nvim then
+    if i ~= #self.mapping.keys.notation then
       table.insert(cmd_line, { " " .. self.options.icons.breadcrumb .. " ", "WhichKeySeparator" })
     end
   end

--- a/lua/which-key/tree.lua
+++ b/lua/which-key/tree.lua
@@ -7,30 +7,31 @@ Tree.__index = Tree
 
 ---@class Node
 ---@field mapping Mapping
----@field prefix string
+---@field prefix_i string
+---@field prefix_n string
 ---@field children table<string, Node>
 -- selene: allow(unused_variable)
 local Node
 
 ---@return Tree
 function Tree:new()
-  local this = { root = { children = {}, prefix = "" } }
+  local this = { root = { children = {}, prefix_i = "", prefix_n = "" } }
   setmetatable(this, self)
   return this
 end
 
----@param prefix string
+---@param prefix_i string
 ---@param index number defaults to last. If < 0, then offset from last
 ---@return Node
-function Tree:get(prefix, index, plugin_context)
-  prefix = Util.parse_keys(prefix).term
+function Tree:get(prefix_i, index, plugin_context)
+  prefix_i = Util.parse_internal(prefix_i)
   local node = self.root
-  index = index or #prefix
+  index = index or #prefix_i
   if index < 0 then
-    index = #prefix + index
+    index = #prefix_i + index
   end
   for i = 1, index, 1 do
-    node = node.children[prefix[i]]
+    node = node.children[prefix_i[i]]
     if node and plugin_context and node.mapping and node.mapping.plugin then
       local children = require("which-key.plugins").invoke(node.mapping, plugin_context)
       node.children = {}
@@ -46,14 +47,14 @@ function Tree:get(prefix, index, plugin_context)
 end
 
 -- Returns the path (possibly incomplete) for the prefix
----@param prefix string
+---@param prefix_i string
 ---@return Node[]
-function Tree:path(prefix)
-  prefix = Util.parse_keys(prefix).term
+function Tree:path(prefix_i)
+  prefix_i = Util.parse_internal(prefix_i)
   local node = self.root
   local path = {}
-  for i = 1, #prefix, 1 do
-    node = node.children[prefix[i]]
+  for i = 1, #prefix_i, 1 do
+    node = node.children[prefix_i[i]]
     table.insert(path, node)
     if not node then
       break
@@ -64,15 +65,18 @@ end
 
 ---@param mapping Mapping
 function Tree:add(mapping)
-  local prefix = mapping.keys.term
+  local prefix_i = mapping.keys.internal
+  local prefix_n = mapping.keys.notation
   local node = self.root
-  local path = ""
-  for i = 1, #prefix, 1 do
-    path = path .. prefix[i]
-    if not node.children[prefix[i]] then
-      node.children[prefix[i]] = { children = {}, prefix = path }
+  local path_i = ""
+  local path_n = ""
+  for i = 1, #prefix_i, 1 do
+    path_i = path_i .. prefix_i[i]
+    path_n = path_n .. prefix_n[i]
+    if not node.children[prefix_i[i]] then
+      node.children[prefix_i[i]] = { children = {}, prefix_i = path_i, prefix_n = path_n }
     end
-    node = node.children[prefix[i]]
+    node = node.children[prefix_i[i]]
   end
   node.mapping = vim.tbl_deep_extend("force", node.mapping or {}, mapping)
 end

--- a/lua/which-key/types.lua
+++ b/lua/which-key/types.lua
@@ -12,13 +12,13 @@
 ---@field script number
 ---@field sid number
 ---@field silent number
----@field id string terminal codes for lhs
+---@field id string internal keycodes for lhs
 local Keymap
 
 ---@class KeyCodes
 ---@field keys string
----@field term string[]
----@field nvim string[]
+---@field internal string[]
+---@field notation string[]
 local KeyCodes
 
 ---@class MappingOptions

--- a/lua/which-key/util.lua
+++ b/lua/which-key/util.lua
@@ -21,27 +21,77 @@ function M.is_empty(tab)
 end
 
 function M.t(str)
-  return vim.api.nvim_replace_termcodes(str, true, true, true)
+  -- https://github.com/neovim/neovim/issues/17369
+  local ret = vim.api.nvim_replace_termcodes(str, false, true, true):gsub("\128\254X", "\128")
+  return ret
 end
+
+-- stylua: ignore start
+local utf8len_tab = {
+  -- ?1 ?2 ?3 ?4 ?5 ?6 ?7 ?8 ?9 ?A ?B ?C ?D ?E ?F
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  -- 0?
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  -- 1?
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  -- 2?
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  -- 3?
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  -- 4?
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  -- 5?
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  -- 6?
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  -- 7?
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  -- 8?
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  -- 9?
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  -- A?
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  -- B?
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,  -- C?
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,  -- D?
+  3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,  -- E?
+  4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 1, 1,  -- F?
+}
+-- stylua: ignore end
 
 ---@return KeyCodes
 function M.parse_keys(keystr)
   local keys = {}
+  local cur = ""
+  local todo = 1
   local special = nil
   for i = 1, #keystr, 1 do
     local c = keystr:sub(i, i)
-    if c == "<" then
+    if special then
+      if todo == 0 then
+        if c == ">" then
+          table.insert(keys, special .. ">")
+          cur = ""
+          todo = 1
+          special = nil
+        elseif c == "-" then
+          -- When getting a special key notation:
+          --   todo = 0 means it can be ended by a ">" now.
+          --   todo = 1 means ">" should be treated as the modified character.
+          todo = 1
+        end
+      else
+        todo = 0
+      end
+      if special then
+        special = special .. c
+      end
+    elseif c == "<" then
       special = "<"
-    elseif c == ">" and special then
-      table.insert(keys, special .. ">")
-      special = nil
-    elseif special then
-      special = special .. c
+      todo = 0
     else
-      table.insert(keys, c)
+      if todo == 1 then
+        todo = utf8len_tab[c:byte() + 1]
+      end
+      cur = cur .. c
+      todo = todo - 1
+      if todo == 0 then
+        table.insert(keys, cur)
+        cur = ""
+        todo = 1
+      end
     end
   end
-  local ret = { keys = M.t(keystr), term = {}, nvim = {} }
+  local ret = { keys = M.t(keystr), internal = {}, notation = {} }
   for i, key in pairs(keys) do
     if key == " " then
       key = "<space>"
@@ -49,10 +99,44 @@ function M.parse_keys(keystr)
     if i == 1 and vim.g.mapleader and M.t(key) == M.t(vim.g.mapleader) then
       key = "<leader>"
     end
-    table.insert(ret.term, M.t(key))
-    table.insert(ret.nvim, key)
+    table.insert(ret.internal, M.t(key))
+    table.insert(ret.notation, key)
   end
   return ret
+end
+
+-- @return string[]
+function M.parse_internal(keystr)
+  local keys = {}
+  local cur = ""
+  local todo = 1
+  local utf8 = false
+  for i = 1, #keystr, 1 do
+    local c = keystr:sub(i, i)
+    if not utf8 then
+      if todo == 1 and c == "\128" then
+        -- K_SPECIAL: get 3 bytes
+        todo = 3
+      elseif cur == "\128" and c == "\252" then
+        -- K_SPECIAL KS_MODIFIER: repeat after getting 3 bytes
+        todo = todo + 1
+      elseif todo == 1 then
+        -- When the second byte of a K_SPECIAL sequence is not KS_MODIFIER,
+        -- the third byte is guaranteed to be between 0x02 and 0x7f.
+        todo = utf8len_tab[c:byte() + 1]
+        utf8 = todo > 1
+      end
+    end
+    cur = cur .. c
+    todo = todo - 1
+    if todo == 0 then
+      table.insert(keys, cur)
+      cur = ""
+      todo = 1
+      utf8 = false
+    end
+  end
+  return keys
 end
 
 function M.log(msg, hl)


### PR DESCRIPTION
Fix #121
Fix #178
Fix #199
Fix #254
Fix #274
Fix #277

Internal keycodes and key notations need to be parsed differently. The `prefix` variable name is very confusing, as it is used for two purposes.