### PR TITLE
Compatibility with Vim Visual Multi plugin

### DIFF
--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -15,6 +15,7 @@ M.auto = false
 M.count = 0
 M.buf = nil
 M.win = nil
+M.is_visual_multi_mode = nil
 
 function M.is_valid()
   return M.buf
@@ -24,6 +25,7 @@ function M.is_valid()
 end
 
 function M.show()
+	M.is_visual_multi_mod = vim.b.visual_multi
   if M.is_valid() then
     return
   end
@@ -130,6 +132,10 @@ function M.hide()
     vim.api.nvim_win_close(M.win, { force = true })
     M.win = nil
   end
+	if M.is_visual_multi_mod then
+		M.is_visual_multi_mod = false
+		vim.cmd[[normal \\gS]] -- reselect visual-multi text
+	end
 end
 
 function M.show_cursor()


### PR DESCRIPTION
fixes https://github.com/folke/which-key.nvim/issues/115 
hack but works.  The underlying problem is caused by which-key popup, which invalidates visual-multi state. This PR checks if before opening WKey popup we were in Visual-multi-mode, if so, then reapply last visual multi state - vim.cmd[[normal \\gS]] 