### PR TITLE
fix(colors): Separator links to DiffAdd

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ The table below shows all the highlight groups defined for **WhichKey** with the
 | ------------------- | ----------- | ------------------------------------------- |
 | *WhichKey*          | Function    | the key                                     |
 | *WhichKeyGroup*     | Keyword     | a group                                     |
-| *WhichKeySeparator* | DiffAdded   | the separator between the key and its label |
+| *WhichKeySeparator* | DiffAdd     | the separator between the key and its label |
 | *WhichKeyDesc*      | Identifier  | the label of the key                        |
 | *WhichKeyFloat*     | NormalFloat | Normal in the popup window                  |
 | *WhichKeyValue*     | Comment     | used by plugins that provide values         |

--- a/lua/which-key/colors.lua
+++ b/lua/which-key/colors.lua
@@ -9,13 +9,16 @@ local links = {
   Value = "Comment",
 }
 
-if vim.fn.hlexists("WhichKeySeperator") then
-  links["Separator"] = "WhichKeySeperator"
-end
-
 function M.setup()
-  for k, v in pairs(links) do
-    vim.api.nvim_command("hi def link WhichKey" .. k .. " " .. v)
+  for k, v in pairs({
+    [""] = "Function",
+    Separator = "DiffAdd",
+    Group = "Keyword",
+    Desc = "Identifier",
+    Float = "NormalFloat",
+    Value = "Comment",
+  }) do
+    vim.api.nvim_set_hl(0, 'WhichKey'..k, {link = v, default = true})
   end
 end
 

--- a/lua/which-key/colors.lua
+++ b/lua/which-key/colors.lua
@@ -2,7 +2,7 @@ local M = {}
 
 local links = {
   [""] = "Function",
-  Separator = "DiffAdded",
+  Separator = "DiffAdd",
   Group = "Keyword",
   Desc = "Identifier",
   Float = "NormalFloat",


### PR DESCRIPTION
The name of highlighting group is [`DiffAdd`](https://neovim.io/doc/user/syntax.html#hl-DiffAdd), not `DiffAdded`