### PR TITLE
Fix mapping when right-hand side is `nil`

### DIFF
--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -254,7 +254,7 @@ function M.map(mode, prefix_n, cmd, buf, opts)
   local other = vim.api.nvim_buf_call(buf or 0, function()
     local ret = vim.fn.maparg(prefix_n, mode, false, true)
     ---@diagnostic disable-next-line: undefined-field
-    return (ret and ret.lhs and ret.rhs ~= cmd) and ret or nil
+    return (ret and ret.lhs and ret.rhs and ret.rhs ~= cmd) and ret or nil
   end)
   if other then
     table.insert(M.duplicates, { mode = mode, prefix = prefix_n, cmd = cmd, buf = buf, other = other })


### PR DESCRIPTION
When a keymap has `!` on the left-hand side and an anonymous function on the right-hand side, mapargs returns a table with no `rhs`, which breaks the test against `cmd`. This only seems to be an issue for this specific `lhs` value.

This PR is a simple fix: it checks to make sure `rhs` exists before testing against `cmd`.