### PR TITLE
fix: feed the keys as typed

### DIFF
--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -192,12 +192,12 @@ function M.execute(prefix_i, mode, buf)
   -- feed CTRL-O again if called from CTRL-O
   local full_mode = Util.get_mode()
   if full_mode == "nii" or full_mode == "nir" or full_mode == "niv" or full_mode == "vs" then
-    vim.api.nvim_feedkeys(Util.t("<C-O>"), "n", false)
+    vim.api.nvim_feedkeys(Util.t("<C-O>"), "nt", false)
   end
 
   -- handle registers that were passed when opening the popup
   if M.reg ~= '"' and M.mode ~= "i" and M.mode ~= "c" then
-    vim.api.nvim_feedkeys('"' .. M.reg, "n", false)
+    vim.api.nvim_feedkeys('"' .. M.reg, "nt", false)
   end
 
   if M.count and M.count ~= 0 then
@@ -205,7 +205,7 @@ function M.execute(prefix_i, mode, buf)
   end
 
   -- feed the keys with remap
-  vim.api.nvim_feedkeys(prefix_i, "m", true)
+  vim.api.nvim_feedkeys(prefix_i, "mt", true)
 
   -- defer hooking WK until after the keys were executed
   vim.defer_fn(function()


### PR DESCRIPTION
Otherwise "gg" cannot open a fold when which-key.nvim is used even if
"jump" flags is in 'foldopen'.
