### PR TITLE
feat: support opts.replace_keycodes for keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Default options for `opts`
   silent = true, -- use `silent` when creating keymaps
   noremap = true, -- use `noremap` when creating keymaps
   nowait = false, -- use `nowait` when creating keymaps
+  expr = false, -- use `expr` when creating keymaps
 }
 ```
 

--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -210,6 +210,8 @@ function M.parse_mappings(mappings, value, prefix_n)
         elseif k == "plugin" then
           mapping.group = true
           mapping.plugin = v
+        elseif k == "replace_keycodes" then
+          mapping.opts.replace_keycodes = v
         else
           error("Invalid key mapping: " .. vim.inspect(value))
         end
@@ -306,6 +308,7 @@ function M.register(mappings, opts)
         noremap = mapping.opts.noremap,
         nowait = mapping.opts.nowait or false,
         expr = mapping.opts.expr or false,
+        replace_keycodes = mapping.opts.replace_keycodes,
       }
       if vim.fn.has("nvim-0.7.0") == 1 then
         keymap_opts.desc = mapping.label

--- a/lua/which-key/types.lua
+++ b/lua/which-key/types.lua
@@ -28,6 +28,7 @@
 ---@field silent boolean
 ---@field nowait boolean
 ---@field expr boolean
+---@field replace_keycodes? boolean
 
 ---@class Mapping
 ---@field buf number


### PR DESCRIPTION
Resolves https://github.com/folke/which-key.nvim/issues/342

My luasnip keymaps were broken after starting to use `which-key.nvim`. This fixes it.

<!--
Kept the default `vim.keymap.set` behavior:

https://github.com/neovim/neovim/blob/a0e6e767a617d79983ac4982850dee6d95ed5b56/runtime/lua/vim/keymap.lua#L42

https://github.com/neovim/neovim/blob/a0e6e767a617d79983ac4982850dee6d95ed5b56/runtime/lua/vim/keymap.lua#L63-L65
-->