### PR TITLE
feat: add popup_user_mappings option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ WhichKey comes with the following defaults:
     winblend = 0
   },
   layout = {
-    height = { min = 4, max = 25 }, -- min and max height of the columns
+    height = { min = 4, max = 25 }, -- min and max height of the lines
     width = { min = 20, max = 50 }, -- min and max width of the columns
     spacing = 3, -- spacing between columns
     align = "left", -- align columns left, center or right

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ WhichKey comes with the following defaults:
     scroll_down = '<c-d>', -- binding to scroll down inside the popup
     scroll_up = '<c-u>', -- binding to scroll up inside the popup
   },
+  -- a table to binding key to function inside the popup. The user-defined function accepts two parameters
+  -- `(keys, mode)`, in which `keys` is the keys bring up the popup, `mode` is the current vim mode.
+  popup_user_mappings = {},
   window = {
     border = "none", -- none, single, double, shadow
     position = "bottom", -- bottom, top

--- a/doc/which-key.txt
+++ b/doc/which-key.txt
@@ -148,6 +148,9 @@ WhichKey comes with the following defaults:
         scroll_down = '<c-d>', -- binding to scroll down inside the popup
         scroll_up = '<c-u>', -- binding to scroll up inside the popup
       },
+      -- a table to binding key to function inside the popup. The user-defined function accepts two parameters
+      -- `(keys, mode)`, in which `keys` is the keys bring up the popup, `mode` is the current vim mode.
+      popup_user_mappings = {},
       window = {
         border = "none", -- none, single, double, shadow
         position = "bottom", -- bottom, top

--- a/doc/which-key.txt
+++ b/doc/which-key.txt
@@ -156,7 +156,7 @@ WhichKey comes with the following defaults:
         winblend = 0
       },
       layout = {
-        height = { min = 4, max = 25 }, -- min and max height of the columns
+        height = { min = 4, max = 25 }, -- min and max height of the lines
         width = { min = 20, max = 50 }, -- min and max width of the columns
         spacing = 3, -- spacing between columns
         align = "left", -- align columns left, center or right

--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -45,6 +45,8 @@ local defaults = {
     scroll_down = "<c-d>", -- binding to scroll down inside the popup
     scroll_up = "<c-u>", -- binding to scroll up inside the popup
   },
+  -- a table to binding key to function inside the popup. The user-defined function accepts two parameters
+  -- `(keys, mode)`, in which `keys` is the keys bring up the popup, `mode` is the current vim mode.
   popup_user_mappings = {},
   window = {
     border = "none", -- none, single, double, shadow

--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -45,6 +45,7 @@ local defaults = {
     scroll_down = "<c-d>", -- binding to scroll down inside the popup
     scroll_up = "<c-u>", -- binding to scroll up inside the popup
   },
+  popup_user_mappings = {},
   window = {
     border = "none", -- none, single, double, shadow
     position = "bottom", -- bottom, top
@@ -53,7 +54,7 @@ local defaults = {
     winblend = 0, -- value between 0-100 0 for fully opaque and 100 for fully transparent
   },
   layout = {
-    height = { min = 4, max = 25 }, -- min and max height of the columns
+    height = { min = 4, max = 25 }, -- min and max height of the lines
     width = { min = 20, max = 50 }, -- min and max width of the columns
     spacing = 3, -- spacing between columns
     align = "left", -- align columns left, center or right
@@ -75,7 +76,7 @@ local defaults = {
   -- Disabled by deafult for Telescope
   disable = {
     buftypes = {},
-    filetypes = {},
+    filetypes = { "TelescopePrompt" },
   },
 }
 

--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -316,17 +316,17 @@ function M.on_keys(opts)
       M.scroll(true)
     elseif c == Util.t("<bs>") then
       M.back()
+    else
+      M.keys = M.keys .. c
     end
 
     for k, fn in pairs(config.options.popup_user_mappings) do
       if c == Util.t(k) then
-        fn(M.keys, opts.mode)
+        fn(M.keys:sub(1, -1 -#c), opts.mode)
         M.hide()
         return
       end
     end
-
-    M.keys = M.keys .. c
   end
 end
 

--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -316,9 +316,17 @@ function M.on_keys(opts)
       M.scroll(true)
     elseif c == Util.t("<bs>") then
       M.back()
-    else
-      M.keys = M.keys .. c
     end
+
+    for k, fn in pairs(config.options.popup_user_mappings) do
+      if c == Util.t(k) then
+        fn(M.keys, opts.mode)
+        M.hide()
+        return
+      end
+    end
+
+    M.keys = M.keys .. c
   end
 end
 


### PR DESCRIPTION
## Summary

This PR add a WK option `popup_user_mappings` (table: string -> function).

With this option, user can binding key to function inside the WK popup.

The user-defined function accepts two parameter `(keys, mode)` , in which `keys` is the keys bring up WK popup, `mode` is the current vim mode.

## Use case

my use case is to fuzzy find the keymaps with above `keys` as a prefix. 
For example to mimic emacs' `<C-h>`, with `Telescope keymaps` :

```
  popup_user_mappings = {
    ['<C-h>'] = function(key, mode)
      require('telescope.builtin').keymaps {
        modes = { mode },
        lhs_filter = function(lhs)
          return vim.startswith(lhs, key)
        end,
      }
    end,
  },
```
![b](https://user-images.githubusercontent.com/45989017/204123502-46a6e8dc-ed27-4e97-9deb-480abc2d07c3.gif)

