### PR TITLE
Add OK output to check_health fn

### DIFF
--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -379,6 +379,10 @@ function M.check_health()
       end
     )
   end
+  if next(M.duplicates) == nil then
+    vim.fn["health#report_ok"]("No conflicting keymaps found")
+    return
+  end
   for _, dup in pairs(M.duplicates) do
     local msg = ""
     if dup.buf == dup.other.buffer then


### PR DESCRIPTION
This PR fixes the issue https://github.com/folke/which-key.nvim/issues/368.

Currently, if no errors are found, check health does not display any concluding message.
This PR adds a simple OK message when no conflicting keymaps are found.