### PR TITLE
feat: Add timeoutlen config for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ WhichKey comes with the following defaults:
   show_keys = true, -- show the currently pressed key and its label as a message in the command line
   triggers = "auto", -- automatically setup triggers
   -- triggers = {"<leader>"} -- or specify a list manually
+  triggers_nowait = {}, -- list of triggers, where WhichKey should not wait for timeoutlen and show immediately
+  plugins_wait = { -- list of plugins and their character triggers where WhichKey should respect timeoutlen
+    marks = {},
+    registers = { "@" },
+    spelling = {},
+  },
   triggers_blacklist = {
     -- list of mode / prefixes that should never be hooked by WhichKey
     -- this is mostly relevant for key maps that start with a native binding

--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -65,6 +65,11 @@ local defaults = {
   triggers = "auto", -- automatically setup triggers
   -- triggers = {"<leader>"} -- or specifiy a list manually
   triggers_nowait = {}, -- list of triggers, where WhichKey should not wait for timeoutlen and show immediately
+  plugins_wait = { -- list of plugins and their character triggers where WhichKey should respect timeoutlen
+    marks = {},
+    registers = { "@" },
+    spelling = {},
+  },
   triggers_blacklist = {
     -- list of mode / prefixes that should never be hooked by WhichKey
     -- this is mostly relevant for keymaps that start with a native binding

--- a/lua/which-key/plugins/marks.lua
+++ b/lua/which-key/plugins/marks.lua
@@ -11,7 +11,16 @@ M.actions = {
 
 function M.setup(_wk, _config, options)
   for _, action in ipairs(M.actions) do
-    table.insert(options.triggers_nowait, action.trigger)
+    local delay = false
+    for _, key in ipairs(options.plugins_wait.marks) do
+      if key == action.trigger then
+        delay = true
+        break
+      end
+    end
+    if not delay then
+      table.insert(options.triggers_nowait, action.trigger)
+    end
   end
 end
 

--- a/lua/which-key/plugins/registers.lua
+++ b/lua/which-key/plugins/registers.lua
@@ -6,14 +6,21 @@ M.name = "registers"
 M.actions = {
   { trigger = '"', mode = "n" },
   { trigger = '"', mode = "v" },
-  { trigger = "@", mode = "n", delay = true },
+  { trigger = "@", mode = "n" },
   { trigger = "<c-r>", mode = "i" },
   { trigger = "<c-r>", mode = "c" },
 }
 
 function M.setup(_wk, _config, options)
   for _, action in ipairs(M.actions) do
-    if not action.delay then
+    local delay = false
+    for _, key in ipairs(options.plugins_wait.registers) do
+      if key == action.trigger then
+        delay = true
+        break
+      end
+    end
+    if not delay then
       table.insert(options.triggers_nowait, action.trigger)
     end
   end

--- a/lua/which-key/plugins/spelling.lua
+++ b/lua/which-key/plugins/spelling.lua
@@ -7,7 +7,17 @@ M.actions = { { trigger = "z=", mode = "n" } }
 M.opts = {}
 
 function M.setup(_, config, options)
-  table.insert(options.triggers_nowait, "z=")
+  local delay = false
+
+  for _, key in ipairs(options.plugins_wait.spelling) do
+    if key == M.actions[0].trigger then
+      delay = true
+      break
+    end
+  end
+  if not delay then
+    table.insert(options.triggers_nowait, "z=")
+  end
   M.opts = config
 end
 


### PR DESCRIPTION
Add timeoutlen respect for:
- Marks
- Registers
- Spelling

via new config option plugins_wait.
Fixes: #152 #220 and was referenced:
https://github.com/folke/which-key.nvim/pull/334
but this PR is opinionated and may not be what the maintainer wishes. This branch repsects the current config settings yet let's some of us add the timeout for these plugins by keymap.