### PR TITLE
Hide mapping when `desc = "which_key_ignore"`

### DIFF
--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -100,7 +100,7 @@ function M.get_mappings(mode, prefix_i, buf)
         ret.mapping = vim.tbl_deep_extend("force", {}, ret.mapping or {}, node.mapping)
       end
       for k, child in pairs(node.children) do
-        if child.mapping and child.mapping.label ~= "which_key_ignore" then
+        if child.mapping and child.mapping.label ~= "which_key_ignore" and child.mapping.desc ~= "which_key_ignore" then
           ret.mappings[k] = vim.tbl_deep_extend("force", {}, ret.mappings[k] or {}, child.mapping)
         end
       end


### PR DESCRIPTION
It would be very convenient to be able to hide a mapping using its `desc` attribute.