### PR TITLE
fix: check that mode is not empty string

### DIFF
--- a/lua/which-key/util.lua
+++ b/lua/which-key/util.lua
@@ -148,8 +148,8 @@ function M.error(msg)
 end
 
 function M.check_mode(mode, buf)
-  if not ("nvsxoiRct"):find(mode) then
-    M.error(string.format("Invalid mode %q for buf %d", mode, buf or 0))
+  if mode == "" or not ("nvsxoiRct"):find(mode) then
+    M.error(string.format("Invalid mode '%q' for buf %d", mode, buf or 0))
     return false
   end
   return true


### PR DESCRIPTION
This PR makes the empty string as the value of the mode illegal:
```lua
wk.register({
  -- some mapping here
}, { mode = "" })
```