### PR TITLE
perf(mappings): avoid computing error string on hot path

### DIFF
--- a/lua/which-key/mappings.lua
+++ b/lua/which-key/mappings.lua
@@ -131,7 +131,9 @@ function M._parse(value, mappings, opts)
 
   -- { desc }
   if #list == 1 then
-    assert(type(list[1]) == "string", "Invalid mapping for " .. vim.inspect({ value = value, opts = opts }))
+    if type(list[1]) ~= "string" then
+      error("Invalid mapping for " .. vim.inspect({ value = value, opts = opts }))
+    end
     opts.desc = list[1]
   -- { cmd, desc }
   elseif #list == 2 then


### PR DESCRIPTION
Profiling with perfanno.nvim shows that a large portion of startup time was spent on this line due to the computation of the error string.

This commit avoids computing the problematic error string unless it is going to be raised.

Startup time as recorded by lazy.nvim shows a reduction of 28% with this change: 13.43ms -> 10.49ms.