### PR TITLE
feat(view): ensure it's above other floating windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ WhichKey comes with the following defaults:
     margin = { 1, 0, 1, 0 }, -- extra window margin [top, right, bottom, left]. When between 0 and 1, will be treated as a percentage of the screen size.
     padding = { 1, 2, 1, 2 }, -- extra window padding [top, right, bottom, left]
     winblend = 0, -- value between 0-100 0 for fully opaque and 100 for fully transparent
+    zindex = 1000, -- positive value to position WhichKey above other floating windows.
   },
   layout = {
     height = { min = 4, max = 25 }, -- min and max height of the columns

--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -51,6 +51,7 @@ local defaults = {
     margin = { 1, 0, 1, 0 }, -- extra window margin [top, right, bottom, left]. When between 0 and 1, will be treated as a percentage of the screen size.
     padding = { 1, 2, 1, 2 }, -- extra window padding [top, right, bottom, left]
     winblend = 0, -- value between 0-100 0 for fully opaque and 100 for fully transparent
+    zindex = 1000, -- positive value to position WhichKey above other floating windows.
   },
   layout = {
     height = { min = 4, max = 25 }, -- min and max height of the columns

--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -68,6 +68,7 @@ function M.show()
     col = margins[4],
     style = "minimal",
     noautocmd = true,
+    zindex = 1000
   }
   if config.options.window.position == "top" then
     opts.anchor = "NW"

--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -68,7 +68,7 @@ function M.show()
     col = margins[4],
     style = "minimal",
     noautocmd = true,
-    zindex = 1000
+    zindex = config.options.window.zindex
   }
   if config.options.window.position == "top" then
     opts.anchor = "NW"


### PR DESCRIPTION
Ensure the which-key window appears above other floating windows, 
such as the LSP diagnostics or terminal that floats.
This improves visibility when using the which-key plugin.