### PR TITLE
feat: allow sorting by description

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ WhichKey comes with the following defaults:
   hidden = { "<silent>", "<cmd>", "<Cmd>", "<CR>", "^:", "^ ", "^call ", "^lua " }, -- hide mapping boilerplate
   show_help = true, -- show a help message in the command line for using WhichKey
   show_keys = true, -- show the currently pressed key and its label as a message in the command line
+  sort_by_description = false, -- sort menu by description instead of keymaps
   triggers = "auto", -- automatically setup triggers
   -- triggers = {"<leader>"} -- or specifiy a list manually
   -- list of triggers, where WhichKey should not wait for timeoutlen and show immediately

--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -64,6 +64,7 @@ local defaults = {
   show_help = true, -- show a help message in the command line for using WhichKey
   show_keys = true, -- show the currently pressed key and its label as a message in the command line
   triggers = "auto", -- automatically setup triggers
+  sort_by_description = false, -- sort menu by description instead of keymaps
   -- triggers = {"<leader>"} -- or specifiy a list manually
   -- list of triggers, where WhichKey should not wait for timeoutlen and show immediately
   triggers_nowait = {


### PR DESCRIPTION
I'd like my maps to be sorted by description (as would some others, see #362), so I implemented an option and comparator function to do just that.

![which-key-sort](https://github.com/folke/which-key.nvim/assets/38540736/b54cba4e-6422-4060-a676-876d56b61132)

