### PR TITLE
Add `config  = true` to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
         -- install plugins
         local plugins = {
           "folke/tokyonight.nvim",
-          "folke/which-key.nvim",
+          { "folke/which-key.nvim", config = true },
           -- add any other plugins here
         }
         require("lazy").setup(plugins, {


### PR DESCRIPTION
When creating #488, I noticed that the `repro.lua` template was missing the actual configuration call for the plugin. 