### PR TITLE
Revert "fix(keys): don't show empty groups"

### DIFF
--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -100,12 +100,7 @@ function M.get_mappings(mode, prefix_i, buf)
         ret.mapping = vim.tbl_deep_extend("force", {}, ret.mapping or {}, node.mapping)
       end
       for k, child in pairs(node.children) do
-        if
-          child.mapping
-          and child.mapping.label ~= "which_key_ignore"
-          and child.mapping.desc ~= "which_key_ignore"
-          and not (child.mapping.group and vim.tbl_isempty(child.children))
-        then
+        if child.mapping and child.mapping.label ~= "which_key_ignore" and child.mapping.desc ~= "which_key_ignore" then
           ret.mappings[k] = vim.tbl_deep_extend("force", {}, ret.mappings[k] or {}, child.mapping)
         end
       end


### PR DESCRIPTION
Fixes #482.

The original empty-group-problem was brought up by @abeldekat, who later commented on the issue [here](https://github.com/folke/which-key.nvim/issues/482#issuecomment-1646770762):
> my suggestion would be: Do show empty group names, as the user configures a group name with intent. The group name unexpectedly being empty shows a mismatch between the intent of the user and the actual code...