### PR TITLE
fix(view): which-key popup doesn't close in command line window

### DIFF
--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -152,7 +152,12 @@ function M.hide()
   vim.api.nvim_echo({ { "" } }, false, {})
   M.hide_cursor()
   if M.buf and vim.api.nvim_buf_is_valid(M.buf) then
-    vim.api.nvim_buf_delete(M.buf, { force = true })
+    -- TODO: Remove in neovim 0.10 (https://github.com/neovim/neovim/issues/24452)
+    if vim.fn.getcmdwintype() ~= "" then
+      pcall(vim.api.nvim_buf_delete, M.buf, { force = true })
+    else
+      vim.api.nvim_buf_delete(M.buf, { force = true })
+    end
     M.buf = nil
   end
   if M.win and vim.api.nvim_win_is_valid(M.win) then


### PR DESCRIPTION
Resolves the following error when attempting to close the which-key popup in the command line window:
```
E5108: Error executing lua ...al/share/nvim/lazy/which-key.nvim/lua/which-key/view.lua:155: E11: Invalid in command-line window; <CR> executes, CTRL-C quits
stack traceback:
	[C]: in function 'nvim_buf_delete'
	...al/share/nvim/lazy/which-key.nvim/lua/which-key/view.lua:155: in function 'hide'
	...al/share/nvim/lazy/which-key.nvim/lua/which-key/view.lua:319: in function 'on_keys'
	...al/share/nvim/lazy/which-key.nvim/lua/which-key/view.lua:254: in function 'open'
	...al/share/nvim/lazy/which-key.nvim/lua/which-key/init.lua:49: in function 'show'
	[string ":lua"]:1: in main chunk
```
See https://github.com/neovim/neovim/issues/24452