### PR TITLE
fix(view): set modifiable flag for view buffer

### DIFF
--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -79,6 +79,7 @@ function M.show()
   vim.api.nvim_buf_set_option(M.buf, "filetype", "WhichKey")
   vim.api.nvim_buf_set_option(M.buf, "buftype", "nofile")
   vim.api.nvim_buf_set_option(M.buf, "bufhidden", "wipe")
+  vim.api.nvim_buf_set_option(M.buf, "modifiable", true)
 
   local winhl = "NormalFloat:WhichKeyFloat"
   if vim.fn.hlexists("FloatBorder") == 1 then


### PR DESCRIPTION
This change provides a fix to somewhat niche use case when user has `nomodifiable` option enabled globally. Currently, if `nomodifiable` option is enabled globally it causes plugin to reach unrecoverable state when 'view' window shows nothing and each key press produces only more Lua exceptions.

Enabling `modifiable` flag on buffer creation ensures the proper state of new scratch buffer, no matter what the current global value is.

Without this change, running `:set nomodifiable` and then pressing any key produces the following exception:
```
E5108: Error executing lua .../which-key.nvim/lua/which-key/view.lua:336: Buffer is not 'modifiable'
stack traceback:
        [C]: in function 'nvim_buf_set_lines'
        .../which-key.nvim/lua/which-key/view.lua:336: in function 'render'
        .../which-key.nvim/lua/which-key/view.lua:313: in function 'on_keys'
        .../which-key.nvim/lua/which-key/view.lua:255: in function 'open'
        .../which-key.nvim/lua/which-key/init.lua:49: in function 'show'
        [string ":lua"]:1: in main chunk
```