### PR TITLE
feat: make replace_keycodes consistent with nvim_set_keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,10 @@ Default options for `opts`
 }
 ```
 
-> ❕ When you specify a command in your mapping that starts with `<Plug>`, then we automatically set `noremap=false`, since you always want recursive keybindings in this case
+> ❕ When you specify a command in your mapping that starts with `<Plug>`, then we automatically set `noremap=false`, since you always want recursive keybindings in this case.
+
+> ❕ Replace_keycodes depends on your Neovim version and whether `expr` is true. For Neovim versions prior to 0.7, `replace_keycodes` will be unset. Else it will follow the
+> default behaviour of being true by default when `expr` is true.
 
 ### ⌨️ Mappings
 

--- a/lua/which-key/mappings.lua
+++ b/lua/which-key/mappings.lua
@@ -21,7 +21,7 @@ local mapargs = {
   "script",
   "unique",
   "callback",
-  "replace_keycodes", -- TODO: add config setting for default value
+  "replace_keycodes",
 }
 local wkargs = {
   "prefix",
@@ -205,6 +205,8 @@ function M.to_mapping(mapping)
       end
       opts.callback = nil
     end
+  elseif opts.expr and opts.replace_keycodes ~= false then
+    opts.replace_keycodes = true
   end
 
   mapping.opts = opts

--- a/lua/which-key/types.lua
+++ b/lua/which-key/types.lua
@@ -7,6 +7,7 @@
 ---@field lhs string
 ---@field buffer number
 ---@field expr number
+---@field replace_keycodes boolean
 ---@field lnum number
 ---@field mode string
 ---@field noremap number
@@ -28,6 +29,7 @@
 ---@field silent boolean
 ---@field nowait boolean
 ---@field expr boolean
+---@field replace_keycodes boolean
 
 ---@class Mapping
 ---@field buf number


### PR DESCRIPTION
Closes #500.

I'm not too sure if this should be categorized as a breaking change, since existing mappings will continue to work but might have a different behaviour than before...