### PR TITLE
feat(keys): `desc` in <nop> keymaps can now become prefix label

### DIFF
--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -135,7 +135,7 @@ function M.get_mappings(mode, prefix_i, buf)
     end
     if not skip then
       if value.group then
-        value.label = value.label or "+prefix"
+        value.label = value.label or value.desc or "+prefix"
         value.label = value.label:gsub("^%+", "")
         value.label = Config.options.icons.group .. value.label
       elseif not value.label then
@@ -416,7 +416,11 @@ function M.update_keymaps(mode, buf)
     local skip = M.is_hook(keymap.lhs, keymap.rhs)
 
     if is_nop(keymap) then
-      skip = true
+      if keymap.desc then
+        keymap.group = true
+      else
+        skip = true
+      end
     end
 
     if not skip then
@@ -424,6 +428,7 @@ function M.update_keymaps(mode, buf)
         prefix = keymap.lhs,
         cmd = keymap.rhs,
         desc = keymap.desc,
+        group = keymap.group,
         callback = keymap.callback,
         keys = Util.parse_keys(keymap.lhs),
       }

--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -204,7 +204,7 @@ function M.execute(prefix_i, mode, buf)
   end
 
   -- make sure we remove all WK hooks before executing the sequence
-  -- this is to make existing keybindongs work and prevent recursion
+  -- this is to make existing keybindings work and prevent recursion
   unhook(Keys.get_tree(mode).tree:path(prefix_i))
   if buf then
     unhook(Keys.get_tree(mode, buf).tree:path(prefix_i), buf)


### PR DESCRIPTION
* User can now use keymaps with <nop> to set `desc` as label to prefix
  key

* Fix some typo

**Example**:
```lua
...
map("n", "<leader>h", "<Nop>", {desc = "Help Prefix"})
map("n", "<leader>p", "<Nop>", {desc = "Projects Prefix"})
map("n", "<leader>f", "<Nop>", {desc = "File Prefix"})
map("n", "<leader>b", "<Nop>", {desc = "Buffer Prefix"})
map("n", "<leader>c", "<Nop>", {desc = "Coding Prefix"})
map("n", "<leader>g", "<Nop>", {desc = "Git Prefix"})
map("n", "<leader>d", "<Nop>", {desc = "Diagnostic Prefix"})
map("n", "<leader>t", "<Nop>", {desc = "Toggle & Setting Prefix"})
...
```
![test](https://github.com/folke/which-key.nvim/assets/43566401/11584e41-989c-4eaa-a66c-14c4b89e789d)
