### PR TITLE
fix: small typo in operator description

### DIFF
--- a/lua/which-key/plugins/presets/init.lua
+++ b/lua/which-key/plugins/presets/init.lua
@@ -12,7 +12,7 @@ M.operators = {
   [">"] = "Indent right",
   ["<lt>"] = "Indent left",
   ["zf"] = "Create fold",
-  ["!"] = "Filter though external program",
+  ["!"] = "Filter through external program",
   ["v"] = "Visual Character Mode",
   -- ["V"] = "Visual Line Mode",
 }


### PR DESCRIPTION
This fixes a small typo in the description of the `!` operator.