### PR TITLE
Add installation instructions for vim-plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ use {
 }
 ```
 
+### [vim-plug](https://github.com/junegunn/vim-plug)
+
+```lua
+vim.cmd([[
+  call plug#begin()
+  Plug 'folke/which-key.nvim', { 'do': ':set timeout timeoutlen=300' }
+  call plug#end()
+]])
+require("which-key").setup {
+  -- your configuration comes here
+  -- or leave it empty to use the default settings
+  -- refer to the configuration section below
+}
+```
+  
+
+
 ## ⚙️ Configuration
 
 > ❗️ IMPORTANT: the [timeout](https://neovim.io/doc/user/options.html#'timeout') when **WhichKey** opens is controlled by the vim setting [timeoutlen](https://neovim.io/doc/user/options.html#'timeoutlen').


### PR DESCRIPTION
vim-plug is a fairly popular package manager for Neovim and Vim.

It took me a bit of time to understand how to convert the installation instructions meant for lazy.nvim and packer into installation instructions that work for vim-plug. I want to save future readers this trouble.