### PR TITLE
keys: Automatically detect key groups

### DIFF
--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -4,8 +4,6 @@ local Config = require("which-key.config")
 
 -- secret character that will be used to create <nop> mappings
 local secret = "Þ"
--- magic description string prefix for nvim-native keybindings to display as groups
-local secret_group = "^WhichKeyGroup:"
 
 ---@class Keys
 local M = {}
@@ -135,7 +133,7 @@ function M.get_mappings(mode, prefix_i, buf)
     if not skip then
       if value.group then
         value.label = value.label or "+prefix"
-        value.label = value.label:gsub("^%+", "")
+        value.label = value.label:gsub(Util.group_pattern, "")
         value.label = Config.options.icons.group .. value.label
       elseif not value.label then
         value.label = value.desc or value.cmd or ""
@@ -420,8 +418,8 @@ function M.update_keymaps(mode, buf)
     end
 
     -- Magic identifier for keygroups in regular keybindings
-    if keymap.desc and keymap.desc:find(secret_group) then
-      keymap.desc = keymap.desc:gsub(secret_group, "")
+    if keymap.desc and keymap.desc:find(Util.group_pattern) then
+      keymap.desc = keymap.desc:gsub(Util.group_pattern, "")
       is_group = true
       skip = false
     end

--- a/lua/which-key/mappings.lua
+++ b/lua/which-key/mappings.lua
@@ -95,7 +95,7 @@ function M._parse(value, mappings, opts)
   end
   if opts.name then
     -- remove + from group names
-    opts.name = opts.name and opts.name:gsub("^%+", "")
+    opts.name = opts.name and opts.name:gsub(Util.group_pattern, "")
     opts.group = true
   end
 

--- a/lua/which-key/util.lua
+++ b/lua/which-key/util.lua
@@ -1,5 +1,8 @@
 ---@class Util
-local M = {}
+local M = {
+  -- prefix for key group identifiers.
+  group_pattern = "^%+",
+}
 local strbyte = string.byte
 local strsub = string.sub
 ---@type table<string, KeyCodes>


### PR DESCRIPTION
from nvim-builtin keymappings. Scans for a magic string in the `desc` field of a keymapping and, if found, removes the magic prefix and registers the respective binding as a group, rather than an action.

This allows defining keybinding groups from outside `which-key`, which can be utilized in conjunction with e.g. the `keys` config option for the `lazy.nvim` plugin manager.

In a `lazy` config snippet, it looks like this:

```
        keys = {
            { "<leader>g",                                      desc = "+git" },
            { "<leader>gg",     "<Cmd>tab Git<CR>",             desc = "overview" },
            { "<leader>gb",                                     desc = "+branch" },
        },
```

If you're interested in merging this I'd be happy to write documentation for this feature to make it discoverable for users. Just let me know!


## Motivation

My motivation for implementing this feature is that I'd like to be able to make my `lazy` plugin configurations fully standalone, so I can drop individual files to a plugins folder and it picks up all my keybindings (in the `keys` config item for lazy loading). At the moment this either requires some "glue" in the `which-key` config file or some boilerplate setup in a plugin-configs `init` key (so it doesn't interfere with the lazy loading mechanism). With this PR one can write a plugins entire keybinding configuration (including keybinding groups) in the `keys` section of the lazy config.

~~In a second step, if this gets merged, I'd like to extend `lazy` to group/shorten keybindings with a common key prefix in the home screen/overview. I have a few plugins with a lot of keybindings, and since lazy currently lists all the triggers in the overview, things become a bit hard to read at times.~~
A proposal for this feature is available here: https://github.com/folke/lazy.nvim/pull/1332


## Things to do

- ~~Using `WhichKeyGroup:` as a prefix was the first thing that came to mind which is reasonably easy to handle in Lua. I'm open to suggestions if this should be changed.~~ Changed to using the "internal" key group prefix `+`.
- The code for "creating" the group binding is pretty wild (i.e. manually injects fields into the `mapping` table in the code, see diff). I didn't find any functions built into the plugin that could do this in a more controlled way, except for `mappings._parse()` which I didn't feel like using (since it seems to be an implementation detail). Again, I'm open to suggestions.


## Other considerations

While implementing this, initially I wanted to match against patters in the `rhs` of a keymapping. However it seems that mappings registered through `lazy`s `keys` config are wrapped into lua functions, making the `rhs` impossible to parse/match on. I guess this makes sense so `lazy` knows when a keybinding was pressed and can load the associated plugin accordingly. So I switched to using the `desc` field instead.

My very first experiments actually consisted of appending the `secret` char defined in `which-key.keys` to a mappings `desc` field. While this does make the binding in question display as group, it does *not* display a label (just the default `+prefix` text). Also it didn't seem like a good idea to expose this implementation detail, so I went with a "magic" prefix instead.