### PR TITLE
fix(ignore_missing): not showing key maps with desc field

### DIFF
--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -126,6 +126,9 @@ function M.get_mappings(mode, prefix_i, buf)
     if Config.options.key_labels[value.key] then
       value.key = Config.options.key_labels[value.key]
     end
+    if not value.label and value.desc then
+      value.label = value.desc
+    end
     local skip = not value.label and Config.options.ignore_missing == true
     if Util.t(value.key) == Util.t("<esc>") then
       skip = true


### PR DESCRIPTION
Fix #355. I tested this locally and it works like a charm.

> Credit goes to @liujoey who opened the original MR https://github.com/folke/which-key.nvim/pull/356.