### PR TITLE
Fix: file/buffer-type disable does not prevent errors being thrown from keys.update function

### DIFF
--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -325,11 +325,13 @@ function M.update(buf)
     if tree.buf and not vim.api.nvim_buf_is_valid(tree.buf) then
       -- remove group for invalid buffers
       M.mappings[k] = nil
-    elseif not buf or not tree.buf or buf == tree.buf then
+    elseif not buf or not tree.buf or buf == tree.buf and
+      require("which-key.view").is_enabled(buf) then
       -- only update buffer maps, if:
       -- 1. we dont pass a buffer
       -- 2. this is a global node
       -- 3. this is a local buffer node for the passed buffer
+      -- 4. which-key is enabled for the buffer.
       M.update_keymaps(tree.mode, tree.buf)
       M.add_hooks(tree.mode, tree.buf, tree.tree.root)
     end


### PR DESCRIPTION
in lua/which-key/init.lua show function:

The show function calls update before checking if which-key is enabled for that buffer type.

the update function can throw an error like the following, for example, in an oil.nvim buffer.

because disable option is not checked before calling it, even disabling which-key for that buffer or file type will not prevent these errors, making it impossible to use any keybinding that would have triggered the popup if it were enabled.

This means, to use oil, I would have to uninstall which-key

I added 1 check to prevent it from executing on disabled buffer and file types.

I thought it best to add the check to the update function itself rather than init's show function, in case it can get called from anywhere else in a disabled buffer.

The error I was getting on any keypress tracked by which-key within oil buffers despite it being disabled for oil filetype:

```
E5108: Error executing lua ...ovimPackages/start/which-key-nvim/lua/which-key/util.lua:128: {
  internal = { "g" },
  keystr = "g\\",
  notation = { "g", "\\" }
}
stack traceback:
        [C]: in function 'error'
        ...ovimPackages/start/which-key-nvim/lua/which-key/util.lua:128: in function 'parse_keys'
        ...ovimPackages/start/which-key-nvim/lua/which-key/keys.lua:425: in function 'update_keymaps'
        ...ovimPackages/start/which-key-nvim/lua/which-key/keys.lua:333: in function 'update'
        ...ovimPackages/start/which-key-nvim/lua/which-key/init.lua:48: in function 'show'
        [string ":lua"]:1: in main chunk
```
Note: I did not press g. I pressed space (my leader key) within an oil buffer in this particular error.