### PR TITLE
fix(is_enabled): disable whichkey in cmdline-window

### DIFF
--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -269,6 +269,10 @@ function M.is_enabled(buf)
       return false
     end
   end
+  
+  if vim.fn.getcmdwintype() ~= "" then
+    return false
+  end
 
   return true
 end


### PR DESCRIPTION
IMHO we can disable whichkey since cmdline-window is restricted.