### PR TITLE
feat(mappings): check if `desc` key exists when parsing mappings

### DIFF
--- a/lua/which-key/mappings.lua
+++ b/lua/which-key/mappings.lua
@@ -134,7 +134,7 @@ function M._parse(value, mappings, opts)
     if type(list[1]) ~= "string" then
       error("Invalid mapping for " .. vim.inspect({ value = value, opts = opts }))
     end
-    opts.desc = list[1]
+    opts.desc = opts.desc or list[1]
   -- { cmd, desc }
   elseif #list == 2 then
     -- desc


### PR DESCRIPTION
There are two patterns of adding a description, with a second string or with the `desc` key.

Legendary.nvim uses the `parse` function from which-key. This function does not check the `desc` key in the table, which should be supported.