### PR TITLE
fix: typo in comment

### DIFF
--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -85,7 +85,7 @@ local defaults = {
     v = { "j", "k" },
   },
   -- disable the WhichKey popup for certain buf types and file types.
-  -- Disabled by deafult for Telescope
+  -- Disabled by default for Telescope
   disable = {
     buftypes = {},
     filetypes = {},


### PR DESCRIPTION
Fix small comment in comment for default config values