### PR TITLE
fix: black hole z= replacements

### DIFF
--- a/lua/which-key/plugins/spelling.lua
+++ b/lua/which-key/plugins/spelling.lua
@@ -41,7 +41,7 @@ function M.run()
       key = key,
       label = label,
       fn = function()
-        vim.cmd("norm! ciw" .. label)
+        vim.cmd('norm! "_ciw' .. label)
       end,
     })
   end


### PR DESCRIPTION
Standard vim and vanilla neovim both blackhole z= replaced words

This makes the behaviour more like a vanilla z= as you don't end up with the misspelt word in your register