### PR TITLE
fix(view): keyboard interrupt errors

### DIFF
--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -84,8 +84,8 @@ end
 function M.read_pending()
   local esc = ""
   while true do
-    local n = vim.fn.getchar(0)
-    if n == 0 then
+    local ok, n = pcall(vim.fn.getchar, 0)
+    if not ok or n == 0 then
       break
     end
     local c = (type(n) == "number" and vim.fn.nr2char(n) or n)


### PR DESCRIPTION
This fixes remaining Keyboard interrupt errors which occasionally happen after pressing <C-c>:
```
E5108: Error executing lua Keyboard interrupt
stack traceback:
        [C]: in function 'getchar'
        ...al/share/nvim/lazy/which-key.nvim/lua/which-key/view.lua:96: in function 'read_pending'
        ...al/share/nvim/lazy/which-key.nvim/lua/which-key/view.lua:281: in function 'on_keys'
        ...al/share/nvim/lazy/which-key.nvim/lua/which-key/view.lua:255: in function 'open'
        ...al/share/nvim/lazy/which-key.nvim/lua/which-key/init.lua:49: in function 'show'
        [string ":lua"]:1: in main chunk
```