### PR TITLE
fix(mappings): make replace_keycodes default to false in v1 spec

### DIFF
--- a/lua/which-key/mappings.lua
+++ b/lua/which-key/mappings.lua
@@ -189,6 +189,9 @@ function M._parse(spec, ret, opts)
       M.error("expected 1 or 2 elements, got " .. count, spec)
     end
   elseif opts.version == 1 then
+    if mapping.expr and mapping.replace_keycodes == nil then
+      mapping.replace_keycodes = false
+    end
     if count == 1 then
       if M.expect(spec, 1, "string") then
         if mapping.desc then


### PR DESCRIPTION
## Description

Old versions of which-key.nvim use `vim.api.nvim_set_keymap()`, which has `replace_keycodes` always default to `false`.

The new version of which-key.nvim uses `vim.keymap.set()`, which has `replace_keycodes` default to `true` if `expr` is `true`.

To not break old specs, make `replace_keycodes` default to `false` there.