### PR TITLE
fix(types): spec field types

### DIFF
--- a/lua/which-key/types.lua
+++ b/lua/which-key/types.lua
@@ -44,8 +44,8 @@
 ---@field icon? wk.Icon|string
 
 ---@class wk.Spec: {[number]: wk.Spec} , wk.Mapping
----@field [1]? string|fun()
----@field [2]? string
+---@field [1]? string
+---@field [2]? string|fun()
 ---@field lhs? string
 ---@field group? string
 ---@field buffer? number|boolean


### PR DESCRIPTION
Fix spec field types for [1] lhs and [2] rhs, as documented in README.