### PR TITLE
feat(view): add option for dynamic height

### DIFF
--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -48,6 +48,7 @@ local defaults = {
   },
   ---@type wk.Win
   win = {
+    dynamic_height = true,
     -- width = 1,
     -- height = { min = 4, max = 25 },
     -- col = 0,

--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -48,7 +48,12 @@ local defaults = {
   },
   ---@type wk.Win
   win = {
-    dynamic_height = true,
+    --- Control dyamic height (try to avoid hiding cursor)
+    --- Can either be a boolean or configured per mode
+    ---@type boolean|table
+    dynamic_height = {
+      x = true,
+    },
     -- width = 1,
     -- height = { min = 4, max = 25 },
     -- col = 0,

--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -380,7 +380,15 @@ function M.show()
   opts.width = opts.width - bw
   opts.height = opts.height - bw
   local cursor = vim.fn.screenrow()
-  if cursor >= opts.row and cursor <= opts.row + opts.height and opts.dynamic_height then
+  local mode = Util.mapmode()
+  local dynamic_height = (function()
+    if type(opts.dynamic_height) == "boolean" then
+      return opts.dynamic_height
+    else
+      return opts.dynamic_height[mode]
+    end
+  end)()
+  if cursor >= opts.row and cursor <= opts.row + opts.height and dynamic_height then
     opts.row = cursor + 1
     opts.height = math.max(vim.o.lines - opts.row, 1)
   end

--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -380,10 +380,11 @@ function M.show()
   opts.width = opts.width - bw
   opts.height = opts.height - bw
   local cursor = vim.fn.screenrow()
-  if cursor >= opts.row and cursor <= opts.row + opts.height then
+  if cursor >= opts.row and cursor <= opts.row + opts.height and opts.dynamic_height then
     opts.row = cursor + 1
     opts.height = math.max(vim.o.lines - opts.row, 1)
   end
+  opts.dynamic_height = nil
 
   if Config.show_help or show_keys then
     text:nl()


### PR DESCRIPTION
## Description

Adds an option which disables the behavior of the window trying to be below the cursorline.

Need to add some docs in the config and perhaps change the name.

Edit: can be configured per mode as well now. Now there also needs to be a discussion about the default value :)

## Related Issue(s)

Fixes https://github.com/folke/which-key.nvim/issues/649

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/5996b190-1869-4708-824c-61a53a915900)

After:
![image](https://github.com/user-attachments/assets/65c6058c-0413-475d-9a8b-3a6968df04c9)