### PR TITLE
fix(win): reset footer in win options, fixes #707

### DIFF
--- a/lua/which-key/win.lua
+++ b/lua/which-key/win.lua
@@ -79,6 +79,7 @@ function M:show(opts)
   win_opts.bo = nil
   win_opts.padding = nil
   win_opts.no_overlap = nil
+  win_opts.footer = nil
 
   if self:valid() then
     win_opts.noautocmd = nil


### PR DESCRIPTION
## Description

Seems like the footer isn't reset and the api function complains because this is an invalid key.
Solution: Reset it like the other additional options.

Haven't tested this so not sure if this is the correct fix.

## Related Issue(s)

https://github.com/folke/which-key.nvim/issues/707