### PR TITLE
fix(view): fix format for keymaps with 3+ keys

### DIFF
--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -64,10 +64,7 @@ function M.format(lhs)
     local parts = vim.split(inner, "-", { plain = true })
     for i, part in ipairs(parts) do
       if i == 1 or i ~= #parts or not part:match("^%w$") then
-        local icon = Config.icons.keys[part]
-        if icon then
-          parts[i] = icon
-        end
+        parts[i] = Config.icons.keys[part] or parts[i]
       end
     end
     return table.concat(parts, "")

--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -62,9 +62,13 @@ function M.format(lhs)
       inner = "C-J"
     end
     local parts = vim.split(inner, "-", { plain = true })
-    parts[1] = Config.icons.keys[parts[1]] or parts[1]
-    if parts[2] and not parts[2]:match("^%w$") then
-      parts[2] = Config.icons.keys[parts[2]] or parts[2]
+    for i, part in ipairs(parts) do
+      if i == 1 or i ~= #parts or not part:match("^%w$") then
+        local icon = Config.icons.keys[part]
+        if icon then
+          parts[i] = icon
+        end
+      end
     end
     return table.concat(parts, "")
   end, keys)


### PR DESCRIPTION
## Description

A minor fix for the format function, which wasn't working correctly for keymaps that include 3 or more keys - see screenshots.

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/e902cc3d-93e0-4e27-90dd-ece366de715b)
### After
![image](https://github.com/user-attachments/assets/c3f8720b-8382-4429-97e1-464b760d1383)

(order is different because of sorting)