### PR TITLE
fix(state): schedule modechanged event handling. Fixes #735

### DIFF
--- a/lua/which-key/state.lua
+++ b/lua/which-key/state.lua
@@ -119,7 +119,9 @@ function M.setup()
         -- make sure the buffer mode exists
       elseif mode and Util.xo() then
         if not M.state then
-          M.start({ defer = defer() })
+          vim.schedule(function()
+            M.start({ defer = defer() })
+          end)
         end
       elseif not ev.match:find("c") then
         M.stop()


### PR DESCRIPTION
## Description

When enabling vim.opt.keymodel = 'startsel' and using the key shift+motion to start a selection (for example shift+Down), the screen is not updated properly with the visual selection until after the ModeChanged event is completed. Re-scheduling the which-key.start() inside the ModeChanged event handler will update the screen properly.

## Related Issue(s)

 - Fixes #735
