### PR TITLE
fix(icons): added frontier pattern for `ai`

### DIFF
--- a/lua/which-key/icons.lua
+++ b/lua/which-key/icons.lua
@@ -47,7 +47,7 @@ M.rules = {
   { pattern = "exit", icon = "󰈆 ", color = "red" },
   { pattern = "quit", icon = "󰈆 ", color = "red" },
   { pattern = "tab", icon = "󰓩 ", color = "purple" },
-  { pattern = "ai", icon = " ", color = "green" },
+  { pattern = "%f[%a]ai", icon = " ", color = "green" },
   { pattern = "ui", icon = "󰙵 ", color = "cyan" },
 }
 


### PR DESCRIPTION
Added frontier pattern for `ai` as it matches on words such as `pair` and probably others as well.
