### PR TITLE
fix(state): improve detection of mode changing

### DIFF
--- a/lua/which-key/state.lua
+++ b/lua/which-key/state.lua
@@ -93,9 +93,9 @@ function M.setup()
   -- this prevents restarting which-key in the same tick
   vim.api.nvim_create_autocmd("ModeChanged", {
     group = group,
-    callback = function(ev)
+    callback = vim.schedule_wrap(function(ev)
       Util.trace("ModeChanged(" .. ev.match .. ")")
-      local mode = Buf.get()
+      local mode = Buf.get({ mode = ev.match:match(":(.+)") })
 
       if cooldown() then
         Util.debug("cooldown")
@@ -121,7 +121,7 @@ function M.setup()
         M.stop()
       end
       Util.trace()
-    end,
+    end),
   })
 
   vim.api.nvim_create_autocmd({ "LspAttach", "LspDetach" }, {


### PR DESCRIPTION
## Description

This helps improve the detection of mode changes in Neovim. It makes 2 small changes.

- It seems like without scheduling the event callbacks for `ModeChanged` events, things can start executing out of order a bit
- It also seems like sometimes the api call for getting the mode of a current buffer lags behind what the actual mode is especially during the `ModeChanged` event until the event is over in some cases. This really seems like some sort of Neovim bug potentially but it is beyond me to really figure out how to debug it to formulate a real core neovim issue. To circumvent this, this takes the `ModeChange` event data which specifies the old mode and new mode as a source of truth and passes that to the rest of the functions

## Related Issue(s)

  - Fixes #787 
