### PR TITLE
fix(typo): change 'explicitely' to 'explicitly' in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ local defaults = {
     group = "+", -- symbol prepended to a group
     ellipsis = "…",
     -- set to false to disable all mapping icons,
-    -- both those explicitely added in a mapping
+    -- both those explicitly added in a mapping
     -- and those from rules
     mappings = true,
     --- See `lua/which-key/icons.lua` for more details

--- a/doc/which-key.nvim.txt
+++ b/doc/which-key.nvim.txt
@@ -211,7 +211,7 @@ Default Options ~
         group = "+", -- symbol prepended to a group
         ellipsis = "…",
         -- set to false to disable all mapping icons,
-        -- both those explicitely added in a mapping
+        -- both those explicitly added in a mapping
         -- and those from rules
         mappings = true,
         --- See `lua/which-key/icons.lua` for more details

--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -125,7 +125,7 @@ local defaults = {
     group = "+", -- symbol prepended to a group
     ellipsis = "…",
     -- set to false to disable all mapping icons,
-    -- both those explicitely added in a mapping
+    -- both those explicitly added in a mapping
     -- and those from rules
     mappings = true,
     --- See `lua/which-key/icons.lua` for more details


### PR DESCRIPTION
## Description

Fix typo in docs.


