### PR TITLE
fix(typo): change "it's" to "its" in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ local defaults = {
   },
   icons = {
     breadcrumb = "»", -- symbol used in the command line area that shows your active key combo
-    separator = "➜", -- symbol used between a key and it's label
+    separator = "➜", -- symbol used between a key and its label
     group = "+", -- symbol prepended to a group
     ellipsis = "…",
     -- set to false to disable all mapping icons,


### PR DESCRIPTION
## Description

Fix typo in docs