### PR TITLE
fix(view): display actual scroll up/down keys in help

### DIFF
--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -445,7 +445,7 @@ function M.show()
         keys[#keys + 1] = { key = "<bs>", desc = "back" }
       end
       if opts.height < text:height() then
-        keys[#keys + 1] = { key = "<c-d>/<c-u>", desc = "scroll" }
+        keys[#keys + 1] = { key = Config.keys.scroll_down .. "/" .. Config.keys.scroll_up, desc = "scroll" }
       end
       local help = Text.new()
       for k, key in ipairs(keys) do


### PR DESCRIPTION
## Description

The footer section of WhichKey window displays help for built-in keys (Esc, BS, scroll up and down). The scroll keys are configurable, however the help message always displays the hard-coded default values.
