### PR TITLE
feat(icons): add grapple icon

### DIFF
--- a/lua/which-key/icons.lua
+++ b/lua/which-key/icons.lua
@@ -22,6 +22,7 @@ M.rules = {
   { plugin = "telescope.nvim", pattern = "telescope", icon = "", color = "blue" },
   { plugin = "trouble.nvim", cat = "filetype", name = "trouble" },
   { plugin = "todo-comments.nvim", cat = "file", name = "TODO" },
+  { plugin = "grapple.nvim", pattern = "grapple", icon = "󰛢", color = "azure" },
   { plugin = "nvim-spectre", icon = "󰛔 ", color = "blue" },
   { plugin = "grug-far.nvim", pattern = "grug", icon = "󰛔 ", color = "blue" },
   { plugin = "noice.nvim", pattern = "noice", icon = "󰈸", color = "orange" },


### PR DESCRIPTION
This adds a default icon for [grapple.nvim](https://github.com/cbochs/grapple.nvim)
