### PR TITLE
fix(buf): disable which-key when recording a macro

### DIFF
--- a/lua/which-key/buf.lua
+++ b/lua/which-key/buf.lua
@@ -66,7 +66,7 @@ function Mode:attach()
     end
   end)
 
-  if Config.triggers.modes[self.mode] then
+  if Config.triggers.modes[self.mode] and vim.fn.reg_recording() == "" then
     -- Auto triggers
     self.tree:walk(function(node)
       if is_safe(node, true) then


### PR DESCRIPTION
## Description

Currently which-key breaks macro recording which makes keys get double recorded. This disables which-key while recording to restore this critical vim functionality.

## Related Issue(s)

- Fixes #822
- Fixes #807
