### PR TITLE
fix(typo): error message spelling of instad to instead

### DIFF
--- a/lua/which-key/state.lua
+++ b/lua/which-key/state.lua
@@ -298,7 +298,7 @@ function M.start(opts)
     Util.error({
       "Recursion detected.",
       "Are you manually loading which-key in a keymap?",
-      "Use `opts.triggers` instad.",
+      "Use `opts.triggers` instead.",
       "Please check the docs.",
     })
     Util.debug("recursion detected. Aborting")


### PR DESCRIPTION
## Description

Fix the spelling in an error message from instad to instead
