### PR TITLE
fix(config): obey notify setting for config validation

### DIFF
--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -234,7 +234,7 @@ function M.setup(opts)
     end
 
     M.validate()
-    if #M.issues > 0 then
+    if #M.issues > 0 and M.notify then
       Util.warn({
         "There are issues with your config.",
         "Use `:checkhealth which-key` to find out more.",


### PR DESCRIPTION
## Description
Obeys notify field for config validation.
Even when calling setup before register, as suggested in linked issue, deprecation warnings still results in the notification being shown, while some other warnings, like overlapping mappings or missing dependencies will not trigger the notification.

It is not clear from checkhealth what warnings will result in the message and which will not.

I would assume notify = false would hide all notifications.

This PR adds a check of notify flag in validation before sending the notification

## Related Issue(s)

  - Fixes ##858
