### PR TITLE
feat: Adds configuration option to spelling plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ local defaults = {
     -- the presets plugin, adds help for a bunch of default keybindings in Neovim
     -- No actual key bindings are created
     spelling = {
-      enabled = true, -- enabling this will show WhichKey when pressing z= to select spelling suggestions
+      trigger = "z=",  -- Key combination to display spelling suggestions using WhichKey
+      enabled = true,  -- If this spelling plugin is enabled
       suggestions = 20, -- how many suggestions should be shown in the list?
     },
     presets = {

--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -2,7 +2,7 @@
 ---@field triggers {mappings: wk.Mapping[], modes: table<string,boolean>}
 local M = {}
 
-M.version = "3.14.1" -- x-release-please-version
+M.version = "3.13.3" -- x-release-please-version
 
 ---@class wk.Opts
 local defaults = {
@@ -38,22 +38,23 @@ local defaults = {
     return ctx.mode == "V" or ctx.mode == "<C-V>"
   end,
   plugins = {
-    marks = true, -- shows a list of your marks on ' and `
+    marks = true,     -- shows a list of your marks on ' and `
     registers = true, -- shows your registers on " in NORMAL or <C-r> in INSERT mode
     -- the presets plugin, adds help for a bunch of default keybindings in Neovim
     -- No actual key bindings are created
     spelling = {
-      enabled = true, -- enabling this will show WhichKey when pressing z= to select spelling suggestions
-      suggestions = 20, -- how many suggestions should be shown in the list?
+      trigger = "z=",  -- Key combination to display spelling suggestions using WhichKey
+      enabled = true,  -- If this spelling plugin is enabled
+      suggestions = 20 -- how many suggestions should be shown in the list?
     },
     presets = {
-      operators = true, -- adds help for operators like d, y, ...
-      motions = true, -- adds help for motions
+      operators = true,    -- adds help for operators like d, y, ...
+      motions = true,      -- adds help for motions
       text_objects = true, -- help for text objects triggered after entering an operator
-      windows = true, -- default bindings on <c-w>
-      nav = true, -- misc bindings to work with windows
-      z = true, -- bindings for folds, spelling and others prefixed with z
-      g = true, -- bindings for prefixed with g
+      windows = true,      -- default bindings on <c-w>
+      nav = true,          -- misc bindings to work with windows
+      z = true,            -- bindings for folds, spelling and others prefixed with z
+      g = true,            -- bindings for prefixed with g
     },
   },
   ---@type wk.Win.opts
@@ -77,11 +78,11 @@ local defaults = {
   },
   layout = {
     width = { min = 20 }, -- min and max width of the columns
-    spacing = 3, -- spacing between columns
+    spacing = 3,          -- spacing between columns
   },
   keys = {
     scroll_down = "<c-d>", -- binding to scroll down inside the popup
-    scroll_up = "<c-u>", -- binding to scroll up inside the popup
+    scroll_up = "<c-u>",   -- binding to scroll up inside the popup
   },
   ---@type (string|wk.Sorter)[]
   --- Mappings are sorted using configured sorters and natural sort of the keys
@@ -110,13 +111,13 @@ local defaults = {
     },
     desc = {
       { "<Plug>%(?(.*)%)?", "%1" },
-      { "^%+", "" },
-      { "<[cC]md>", "" },
-      { "<[cC][rR]>", "" },
-      { "<[sS]ilent>", "" },
-      { "^lua%s+", "" },
-      { "^call%s+", "" },
-      { "^:%s*", "" },
+      { "^%+",              "" },
+      { "<[cC]md>",         "" },
+      { "<[cC][rR]>",       "" },
+      { "<[sS]ilent>",      "" },
+      { "^lua%s+",          "" },
+      { "^call%s+",         "" },
+      { "^:%s*",            "" },
     },
   },
   icons = {

--- a/lua/which-key/plugins/spelling.lua
+++ b/lua/which-key/plugins/spelling.lua
@@ -4,20 +4,20 @@ local M = {}
 
 M.name = "spelling"
 
-M.mappings = {
-  {
-    "z=",
-    icon = { icon = " ", color = "red" },
-    plugin = "spelling",
-    desc = "Spelling Suggestions",
-  },
-}
-
 ---@type table<string, any>
 M.opts = {}
 
 function M.setup(opts)
   M.opts = opts
+
+  require("which-key.config").add({
+    {
+      M.opts.trigger,
+      icon = { icon = " ", color = "red" },
+      plugin = "spelling",
+      desc = "Spelling Suggestions",
+    },
+  })
 end
 
 function M.expand()


### PR DESCRIPTION
Added a "trigger" configuration option under "spelling". With it, the user can assign the key combination to trigger the spelling plugin. The default value is set to be the previously hardcoded value "z=".

## Description

The usage of Whichkey is imperative when extensively modifying default keybindings, as it allows one to document all changes made while they are being made at the level of configuration. In turn, having hardcoded keybindings inside WhichKey is counter productive to that goal.

## Related Issue(s)

Solves #866