### PR TITLE
feat(WhichKey): the WhichKey command displays keymaps for current mode

### DIFF
--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -310,7 +310,7 @@ function M.setup(opts)
       return require("which-key.util").error("Usage: WhichKey [mode] [keys]")
     end
     if mode == "" then
-      mode = "n"
+      mode = vim.api.nvim_get_mode().mode
     end
     require("which-key").show({ mode = mode, keys = keys })
   end, {


### PR DESCRIPTION
## Description

Invoking the `WhichKey` command with a keymap should display the keymaps for the current mode, not normal mode. Showing normal mode keymaps when invoking the command from e.g. insert or visual mode is confusing.

## Related Issue(s)

- Fixes #914 