### PR TITLE
feat(icons): add undotree pattern icon

### DIFF
--- a/lua/which-key/icons.lua
+++ b/lua/which-key/icons.lua
@@ -54,6 +54,7 @@ M.rules = {
   { pattern = "tab", icon = "󰓩 ", color = "purple" },
   { pattern = "%f[%a]ai", icon = " ", color = "green" },
   { pattern = "ui", icon = "󰙵 ", color = "cyan" },
+  { pattern = "undotree", icon = "󰙅 ", color = "orange" },
 }
 
 ---@type wk.IconProvider[]


### PR DESCRIPTION
## Description

As it reads on the tin can. Depends on #935 to take effect, but can be merged independently.

## Related Issue(s)

N/A

## Screenshots

### With #935 fix

![Screenshot 2025-01-23 at 11 35 38](https://github.com/user-attachments/assets/d2a7573b-cfdd-4af4-b21d-ddc1645e4d54)


### Without #935 fix

![Screenshot 2025-01-23 at 11 35 57](https://github.com/user-attachments/assets/9817d089-0377-41dc-a5b5-ac67b0650261)
