### PR TITLE
feat(icons): added icons pattern icon

### DIFF
--- a/lua/which-key/icons.lua
+++ b/lua/which-key/icons.lua
@@ -54,6 +54,7 @@ M.rules = {
   { pattern = "tab", icon = "󰓩 ", color = "purple" },
   { pattern = "%f[%a]ai", icon = " ", color = "green" },
   { pattern = "ui", icon = "󰙵 ", color = "cyan" },
+  { pattern = "icon", icon = " ", color = "yellow" },
 }
 
 ---@type wk.IconProvider[]


### PR DESCRIPTION
## Description

For `snack.icons` picker and similar. Depends on https://github.com/folke/which-key.nvim/pull/935 to take effect, but can be merged independently.

## Related Issue(s)

N/A

## Screenshots

### With #935 fix
![Screenshot 2025-01-25 at 21 26 19](https://github.com/user-attachments/assets/7244a44b-b598-4aba-85dd-bb32e6740b1b)

### Without fix

![Screenshot 2025-01-25 at 21 26 51](https://github.com/user-attachments/assets/d4656492-4756-4363-9bb5-024428ad5de3)