### PR TITLE
fix(icons): narrowed 'ui' matching pattern

### DIFF
--- a/lua/which-key/icons.lua
+++ b/lua/which-key/icons.lua
@@ -53,7 +53,7 @@ M.rules = {
   { pattern = "quit", icon = "󰈆 ", color = "red" },
   { pattern = "tab", icon = "󰓩 ", color = "purple" },
   { pattern = "%f[%a]ai", icon = " ", color = "green" },
-  { pattern = "ui", icon = "󰙵 ", color = "cyan" },
+  { pattern = "%f[%a]ui", icon = "󰙵 ", color = "cyan" },
 }
 
 ---@type wk.IconProvider[]


### PR DESCRIPTION
## Description

`"ui"` pattern was matching any words with `ui` in them, e.g. `"Quickfix List"` in the screenshot below. This narrows the pattern down so it only matches the actual word.

## Related Issue(s)

N/A

## Screenshots

### Before

![Screenshot 2025-01-25 at 21 32 06](https://github.com/user-attachments/assets/92e7abcd-8d9d-4017-a4c9-0b25764cd86d)

### After

![Screenshot 2025-01-25 at 21 32 38](https://github.com/user-attachments/assets/12997990-7979-414d-ba82-8e53b788ad51)
