### PR TITLE
fix(state): defer buffer mappings loading to fix localleader menu

### DIFF
--- a/lua/which-key/state.lua
+++ b/lua/which-key/state.lua
@@ -144,9 +144,12 @@ function M.setup()
     group = group,
     callback = function(ev)
       current_buf = ev.buf ---@type number
-      Util.trace(ev.event .. "(" .. ev.buf .. ")")
-      Buf.get()
-      Util.trace()
+      -- move to end of event loop to give time to set localleader mappings
+      vim.defer_fn(function()
+        Util.trace(ev.event .. "(" .. ev.buf .. ")")
+        Buf.get()
+        Util.trace()
+      end, 0)
     end,
   })
 


### PR DESCRIPTION
## Description

The ⁠`which-key` menu fails to appear for `⁠localleader` mappings in newly created buffers. Currently, the only way to make it work is to trigger the standard `⁠leader` menu first, which seems to force a state update.

It appears that ⁠`which-key` attempts to load buffer mappings before the ⁠`localleader` mappings are fully registered. Triggering the `⁠leader` menu resolves this because it re-reads the mappings, at which point they are available.

This PR defers the reading of the buffer state. This ensures that all mappings are fully established before ⁠`which-key` attempts to index them, effectively resolving the race condition.

## Related Issue(s)

  - Fixes #476 (still exists)

