### PR TITLE
Added an extras function for tab mappings, similar to buffers and windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ The `expand` property allows to create dynamic mappings. Only functions as `rhs`
 Two examples are included in `which-key.extras`:
 
 - `require("which-key.extras").expand.buf`: creates numerical key to buffer mappings
+- `require("which-key.extras").expand.tab`: creates numerical key to tab mappings
 - `require("which-key.extras").expand.win`: creates numerical key to window mappings
 
 ```lua

--- a/lua/which-key/extras.lua
+++ b/lua/which-key/extras.lua
@@ -67,4 +67,25 @@ function M.expand.win()
   return M.add_keys(ret)
 end
 
+function M.expand.tab()
+    local ret = {}
+    local current = vim.api.nvim_get_current_tabpage()
+    vim.print("Current = " .. current)
+    for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+        vim.print(tab)
+        if tab ~= current then
+            local num = vim.api.nvim_tabpage_get_number(tab)
+            ret[#ret + 1] = {
+            "",
+            function ()
+               vim.api.nvim_set_current_tabpage(tab)
+            end,
+            desc = "Goto tab " .. tostring(num),
+            icon = { cat = "file", name = tostring(num) },
+        }
+        end
+    end
+    return M.add_keys(ret)
+end
+
 return M


### PR DESCRIPTION
## Description

It's an easy, single-function, single-line-of-documentation change to add support for expanding tabs just like buffers and windows. I find it helpful now that I use tabs a lot more often.

## Related Issue(s)

(none)

## Screenshots

(none)

