### PR TITLE
perf: small perf optims

### DIFF
--- a/lua/which-key/util.lua
+++ b/lua/which-key/util.lua
@@ -7,7 +7,10 @@ M.cache = {
 }
 
 function M.t(str)
-  M.cache.termcodes[str] = M.cache.termcodes[str] or vim.api.nvim_replace_termcodes(str, true, true, true)
+  if M.cache.termcodes[str] then
+    return M.cache.termcodes[str]
+  end
+  M.cache.termcodes[str] = vim.api.nvim_replace_termcodes(str, true, true, true)
   return M.cache.termcodes[str]
 end
 


### PR DESCRIPTION
I noticed that there are two similar caching patterns in the codebase with slightly different implementations. Specifically, the M.t function uses a short-circuit evaluation pattern while M.norm uses an explicit if-check:

```
-- M.t uses short-circuit evaluation
function M.t(str)
  M.cache.termcodes[str] = M.cache.termcodes[str] or vim.api.nvim_replace_termcodes(str, true, true, true)
  return M.cache.termcodes[str]
end
```

```
-- M.norm uses explicit if-check
function M.norm(lhs)
  if M.cache.norm[lhs] then
    return M.cache.norm[lhs]
  end
  M.cache.norm[lhs] = vim.fn.keytrans(M.t(lhs))
  return M.cache.norm[lhs]
end

```

I think it might be beneficial to unify these patterns for better code consistency. I'm not sure if this small change is worth a PR, I just wanted to contribute a small improvement to this excellent plugin.