### PR TITLE
feat(vscode): make which-key.nvim usable in vscode

### DIFF
--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -135,6 +135,9 @@ function M.hide()
     M.footer:hide()
     M.footer = nil
   end
+  if vim.g.vscode ~= nil and type(vim.g.vscode_update) == "function" then
+    vim.g.vscode_update()
+  end
 end
 
 ---@param field string
@@ -477,6 +480,9 @@ function M.show()
   vim.api.nvim_win_call(M.view.win, function()
     vim.fn.winrestview({ topline = 1 })
   end)
+  if vim.g.vscode ~= nil and type(vim.g.vscode_update) == "function" then
+    vim.g.vscode_update(M.view.buf)
+  end
   vim.cmd.redraw()
 end
 


### PR DESCRIPTION
## Description

As we know, `which-key.nvim` can not be used in vscode via the extension `vscode-neovim`, as the vscode does not support floating pane, seeing https://github.com/folke/which-key.nvim/discussions/592#discussioncomment-8880223. But it's really a neccessary to have a keymap tip as there's so many keymaps in neovim need to remember.

So I decide to make `which-key.nvim` usable in vscode. I choose a text protocal based UDP protocal to sync the tip content of which-key.nvim then show them in a external floating window written by Python which you can rewrite in any other language.

## Related Issue(s)

- https://github.com/folke/which-key.nvim/discussions/592
- https://github.com/folke/which-key.nvim/discussions/485

## Screenshots

![which-key](https://github.com/user-attachments/assets/8c073e45-d6a7-4854-9736-ff359c3850d0)

Here's a example. One thing I need to say that I use Trae, which is an IDE released by ByteDance based vscode with free AI, but I think the demo is no different with vscode, I can install vscode-neovim extension too.

The `init.lua` config👇
```lua
if vim.g.vscode ~= nil then
  local udp = vim.loop.new_udp("inet4")
  vim.g.vscode_update = function(buf)
    if buf ~= nil then
      local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
      local content = table.concat(lines, "\n")
      local length = string.len(content)
      local high = math.floor(length / 256)
      local low = length % 256
      udp:send(string.char(high, low) .. content, "127.0.0.1", 6000)
    else
      udp:send(string.char(0, 1) .. " ", "127.0.0.1", 6000)
    end
  end
end
```

Python code👇
```python
import tkinter as tk

import threading
import struct
import socket


class WinApp:
    def __init__(self) -> None:
        self.root = tk.Tk()
        self.root.title("Which Key")
        self.root.attributes("-topmost", True)
        self.root.minsize(540, 10)
        # 配置网格布局权重，使文本框可以扩展
        self.root.grid_rowconfigure(0, weight=1)
        self.root.grid_columnconfigure(0, weight=1)

        # 创建带滚动条的文本框
        self.text_box = tk.Text(
            self.root,
            wrap="word",
            state="disabled",
            font=("DaddyTimeMono Nerd Font Mono", 12),
        )
        # 布局控件
        self.text_box.grid(row=0, column=0, sticky="nsew")
        self.line_height = 20
        self.set_text(" ")

        self.server = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

    def set_text(self, text):
        self.text_box.config(state="normal")
        self.text_box.delete(1.0, "end")  # 新增清空操作
        self.text_box.insert("end", text)
        self.text_box.config(state="disabled")

        window_width = self.root.winfo_width()  # 保持当前宽度

        length = len(text)
        if length <= 1:
            pos_x = -1000
            pos_y = -1000
            new_height = 10
        else:
            # 动态计算窗口高度
            lines = int(self.text_box.index("end-1c").split(".")[0])  # 获取总行数
            new_height = lines * self.line_height + 5

            # 计算右下角坐标
            screen_width = self.root.winfo_screenwidth()
            screen_height = self.root.winfo_screenheight()
            pos_x = screen_width - window_width - 20  # 右边距10像素
            pos_y = screen_height - new_height - 90  # 下边距80像素

        print(f"new height: {window_width}, {new_height}")
        self.root.geometry(f"{window_width}x{new_height}+{pos_x}+{pos_y}")  # 应用新尺寸

    def run(self):
        try:
            self.start_udp_server()
            self.set_text("")
            self.root.mainloop()
        finally:
            self.server.close()

    def _start_udp_server(self):
        self.server.bind(("127.0.0.1", 6000))
        buffer = b""
        while True:
            data, _ = self.server.recvfrom(1024 * 10)
            buffer += data
            while len(buffer) >= 2:
                try:
                    length = struct.unpack(">H", buffer[:2])[0]  # 读取长度头
                    if len(buffer) < length + 2:
                        break
                    if length:
                        payload = buffer[2 : 2 + length].decode()
                        buffer = buffer[2 + length :]
                        self.set_text(payload)

                        print(f"Received: {payload}")
                except struct.error:
                    break

    def start_udp_server(self):
        self.thread = threading.Thread(target=self._start_udp_server)
        self.thread.start()


if __name__ == "__main__":
    app = WinApp()
    app.run()

```