### PR TITLE
feat(window): add vim.o.winborder support

### DIFF
--- a/lua/which-key/presets.lua
+++ b/lua/which-key/presets.lua
@@ -7,7 +7,7 @@ return {
       padding = { 0, 1 },
       col = -1,
       row = -1,
-      border = "rounded",
+      border = vim.o.winborder or "rounded",
       title = true,
       title_pos = "left",
     },
@@ -21,7 +21,7 @@ return {
       height = { min = 4, max = 25 },
       col = 0.5,
       row = -1,
-      border = "rounded",
+      border = vim.o.winborder or "rounded",
       title = true,
       title_pos = "center",
     },
@@ -32,7 +32,7 @@ return {
       height = { min = 4, max = 25 },
       col = 0,
       row = -1,
-      border = "none",
+      border = vim.o.winborder or "none"
     },
   },
 }

--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -463,6 +463,7 @@ function M.show()
     M.footer = M.footer or Win.new()
     M.footer:show({
       relative = "win",
+      border = "none",
       win = M.view.win,
       col = 0,
       row = opts.height - 1,


### PR DESCRIPTION
## Description

Add support for `vim.o.winborder`, this a new option that 'Defines the default border style of floating windows. The default value is empty, which is equivalent to "none"'