### PR TITLE
fix(view): double footer border. Fixes folke#964

### DIFF
--- a/lua/which-key/view.lua
+++ b/lua/which-key/view.lua
@@ -469,6 +469,7 @@ function M.show()
       width = opts.width,
       height = 1,
       zindex = M.view.opts.zindex + 1,
+      border = "none",
     })
     footer:render(M.footer.buf)
   end


### PR DESCRIPTION
## Description

Explicit set footer border to none which handles the case if the new winborder option in nvim-0.11 is set.

## Related Issue(s)

folke#964

## Screenshots


<img width="870" alt="Screenshot 2025-04-12 at 11 46 44" src="https://github.com/user-attachments/assets/84c4eab6-21b5-4b75-b787-3f8ad8fa5b27" />

