### PR TITLE
feat(config): allow the configuration of filename modifiers

### DIFF
--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -175,6 +175,8 @@ local defaults = {
     bt = {},
   },
   debug = false, -- enable wk.log in the current directory
+  -- https://vimdoc.sourceforge.net/htmldoc/cmdline.html#filename-modifiers
+  filename_modifier = ":~:.", --":t",
 }
 
 M.loaded = false

--- a/lua/which-key/extras.lua
+++ b/lua/which-key/extras.lua
@@ -1,3 +1,5 @@
+local Config = require("which-key.config")
+
 local M = {}
 
 ---@type table<string, fun():wk.Spec>
@@ -13,7 +15,13 @@ end
 
 function M.bufname(buf)
   local name = vim.api.nvim_buf_get_name(buf)
-  return name == "" and "[No Name]" or vim.fn.fnamemodify(name, ":~:.")
+  local filename_modifier = ":~:."
+
+  if Config.options.filename_modifier and Config.options.filename_modifier ~= "" then
+    filename_modifier = Config.options.filename_modifier
+  end
+
+  return name == "" and "[No Name]" or vim.fn.fnamemodify(name, filename_modifier)
 end
 
 ---@param spec wk.Spec[]


### PR DESCRIPTION
## Description

Just a tweak I've came up with. I work in some Java projects in which  my files are stored deeply in the directories structure. When triggering the buffers UI in my Lazyvim  (`<leader>b`) I'm not able to see the filename because it is hidden by the UI's width limitation.

I discovered that the filename used in the buffers list is actually defined through the [fnamemodify()](https://vimdoc.sourceforge.net/htmldoc/eval.html#fnamemodify()) Vim function, which takes a string as argument with some pattern that will convert the full path of the file in many ways, including just the filename, which is what I prefer.

The PR changes the defaults config object so a new `filename_modifier` parameter could be set by the user. This value will then be used in the `bufname()` function, keeping the current ":~:." pattern as a default.

After changing the plugin's code I'm now able to have the following config customization file in my Lazyvim:

```lua
{
    "folke/which-key.nvim",
    opts = { filename_modifier = ":t." },
  },
}
```
Now instead of having this in my buffers menu...

```
0 src/main/java/br/rs/gov/
1 src/main/java/br/rs/gov/
2 src/main/java/br/rs/gov/
...
```

...I can easily identify the buffers by its names:

```
0 FileA.java
1 FileB.java
2 FileC.java
...
```

I don't know if there was another easier way to achieve the same thing, just went ahead with this tweak and it'sworking for me.

## Related Issue(s)


## Screenshots

<!-- Add screenshots of the changes if applicable. -->

