### PR TITLE
fix(presets): correct sub-mappings typos for ‘]’ prefix

### DIFF
--- a/lua/which-key/plugins/presets.lua
+++ b/lua/which-key/plugins/presets.lua
@@ -169,12 +169,12 @@ M.nav = {
   { "[s", desc = "Previous misspelled word" },
   { "[{", desc = "Previous {" },
   { "]%", desc = "Next unmatched group" },
-  { "](", desc = "Next (" },
-  { "]<", desc = "Next <" },
+  { "])", desc = "Next )" },
+  { "]>", desc = "Next >" },
   { "]M", desc = "Next method end" },
   { "]m", desc = "Next method start" },
   { "]s", desc = "Next misspelled word" },
-  { "]{", desc = "Next {" },
+  { "]}", desc = "Next }" },
 }
 
 M.g = {


### PR DESCRIPTION
## Description

The sub-mappings for the built-in key ] are incorrectly described. Looks like a copy-paste error. Changed:

- ]( to ]) and updated description to match
- ]< to ]> and updated description to match
- ]{ to ]} and updated description to match


## Related Issue(s)

## Screenshots

