### PR TITLE
fix(mappings): add keybinds for ZZ/ZQ

### DIFF
--- a/lua/which-key/plugins/presets.lua
+++ b/lua/which-key/plugins/presets.lua
@@ -154,7 +154,7 @@ M.z = {
   { "zw", desc = "Mark word as bad/misspelling" },
   { "zx", desc = "Update folds" },
   { "zz", desc = "Center this line" },
-  { "ZZ", desc = "Save and quit" },
+  { "ZZ", desc = "Update and quit" },
   { "ZQ", desc = "Quit without saving" },
 }
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Learned about these keybinds recently, not sure why they aren't included.
I searched ZZ in pull requests and nothing seemed to show, so I decided to try making a pull request myself. If there is a reason for not including ZZ, this can simply be closed.

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
<img width="1064" height="172" alt="image" src="https://github.com/user-attachments/assets/0b282023-b143-47c4-a64e-5db5ac844b3b" />

