### PR TITLE
fix(health): avoid checking virtual mappings in keymapping overlap health check

### DIFF
--- a/lua/which-key/health.lua
+++ b/lua/which-key/health.lua
@@ -104,7 +104,9 @@ function M.check()
             if node.desc and node.desc ~= "" then
               descs[#descs + 1] = "- <" .. node.keys .. ">: " .. node.desc
             end
-            local queue = node:children()
+            -- Only check real children (_children), not plugin expansions
+            -- Plugin expansions are virtual and don't cause actual keymap conflicts
+            local queue = vim.tbl_values(node._children)
             while #queue > 0 do
               local child = table.remove(queue)
               if child.keymap then
@@ -113,7 +115,7 @@ function M.check()
                   descs[#descs + 1] = "- <" .. child.keys .. ">: " .. child.desc
                 end
               end
-              vim.list_extend(queue, child:children())
+              vim.list_extend(queue, vim.tbl_values(child._children))
             end
             if #overlaps > 0 then
               found = true


### PR DESCRIPTION
## Description
### Issue

The `:checkhealth which-key` command was reporting bogus overlapping keymap warnings like:

```javascript
⚠️ WARNING In mode `n`, <1> overlaps with <16>, <15>, <14>, <13>, <12>, <11>, <10>, <19>, <18>, <17>:
```

However, when users checked with `:nmap`, they found no actual keymaps for sequences like `10`, `11`, `12`, etc. This caused confusion as the warnings appeared to be false positives.

### Root Cause

The health check was incorrectly treating __plugin expansion children__ as real vim keymaps when checking for overlaps.

Which-key has two types of entries in its tree structure:

1. __Real keymaps__ (`node.keymap`): Actual vim keymaps registered via `:nmap`, `:imap`, etc.
2. __Virtual mappings__ (`node.mapping`): Display-only entries generated dynamically by plugins

For example, the registers plugin creates a mapping for `"` that, when triggered, dynamically expands to show available registers (`"0`, `"1`, `"2`, etc.). These expanded entries are __virtual__ - they only exist in the which-key popup and are not actual vim keymaps that would cause timeout behavior.

The health check was calling `node:children()` which includes both real children (from `node._children`) and plugin expansion children (generated by `node:expand()`). This caused it to report overlaps with virtual entries that don't actually cause keymap conflicts.

### Solution

Modified the overlap detection in `lua/which-key/health.lua` to only check `node._children` (real vim keymaps) instead of `node:children()` (which includes plugin expansions).

__Changes:__

- Line 103: `node:children()` → `vim.tbl_values(node._children)`
- Line 112: `child:children()` → `vim.tbl_values(child._children)`
- Added explanatory comments

This ensures the health check only warns about actual keymap conflicts where vim would wait for a timeout, not virtual plugin expansion entries.

### Testing

After this fix, running `:checkhealth which-key` should no longer show false positive warnings for plugin expansion entries. Only genuine keymap overlaps (where one keymap is a prefix of another actual vim keymap) will be reported.



## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

Original issue:
<img width="836" height="528" alt="image" src="https://github.com/user-attachments/assets/a18dd582-0e23-4362-841a-996fd801d112" />


