### PR TITLE
fix(registers): improve detection of osc52 registers

### DIFF
--- a/lua/which-key/plugins/registers.lua
+++ b/lua/which-key/plugins/registers.lua
@@ -62,7 +62,7 @@ function M.expand()
     local key = M.registers:sub(i, i)
     local value = ""
     if is_osc52(key) then
-      value = "OSC 52 detected, register not checked to maintain compatibility"
+      value = "[OSC 52 detected]"
     elseif has_clipboard or not key:match("[%+%*]") then
       local ok, reg_value = pcall(vim.fn.getreg, key, 1)
       value = (ok and reg_value or "") --[[@as string]]

--- a/lua/which-key/plugins/registers.lua
+++ b/lua/which-key/plugins/registers.lua
@@ -37,16 +37,27 @@ M.replace = {
   ["\r"] = "",
 }
 
+local function is_osc52(key)
+  if not key:match("[%+%*]") or not vim.g.clipboard then
+    return false
+  end
+  if vim.g.clipboard == "osc52" then
+    return true
+  end
+  if type(vim.g.table) ~= "table" or not vim.g.clipboard.paste then
+    return false
+  end
+  return vim.g.clipboard.paste[key] == require("vim.ui.clipboard.osc52").paste(key)
+end
+
 function M.expand()
   local items = {} ---@type wk.Plugin.item[]
-
-  local is_osc52 = vim.g.clipboard and vim.g.clipboard.name == "OSC 52"
   local has_clipboard = vim.g.loaded_clipboard_provider == 2
 
   for i = 1, #M.registers, 1 do
     local key = M.registers:sub(i, i)
     local value = ""
-    if is_osc52 and key:match("[%+%*]") then
+    if is_osc52(key) then
       value = "OSC 52 detected, register not checked to maintain compatibility"
     elseif has_clipboard or not key:match("[%+%*]") then
       local ok, reg_value = pcall(vim.fn.getreg, key, 1)

--- a/lua/which-key/plugins/registers.lua
+++ b/lua/which-key/plugins/registers.lua
@@ -44,10 +44,14 @@ local function is_osc52(key)
   if vim.g.clipboard == "osc52" then
     return true
   end
-  if type(vim.g.table) ~= "table" or not vim.g.clipboard.paste then
+  if type(vim.g.table) ~= "table" then
     return false
   end
-  return vim.g.clipboard.paste[key] == require("vim.ui.clipboard.osc52").paste(key)
+  if vim.g.clipboard.name == "OSC 52" then
+    return true
+  end
+  return vim.g.clipboard.paste and
+      vim.g.clipboard.paste[key] == require("vim.ui.clipboard.osc52").paste(key)
 end
 
 function M.expand()


### PR DESCRIPTION
The prior implementation assumed that registers `+` and `*` used OSC52 if and only if `vim.g.clipboard.name = "OSC 52"`. Doing so is incorrect: a user may configure a custom clipboard provider with a different name, or set a different paste source for `+` or `*`, or even set the option to a string as shorthand, i.e., `vim.g.clipboard = 'osc52'`.

This implementation performs more robust checking to ensure we don't try to read from OSC52 registers by discriminating `vim.g.clipboard` more closely. It still checks for `vim.g.clipboard.name == "OSC 52"` for backwards compatibility and to provide a way for those who might use a custom paste handler that isn't exactly the nvim-provided one.

I also shorten to placeholder message of OSC 52 registers.