### PR TITLE
perf: registers freeze nvim when they contain large content

### DIFF
--- a/lua/which-key/config.lua
+++ b/lua/which-key/config.lua
@@ -39,7 +39,20 @@ local defaults = {
   end,
   plugins = {
     marks = true, -- shows a list of your marks on ' and `
-    registers = true, -- shows your registers on " in NORMAL or <C-r> in INSERT mode
+    registers = {
+      enabled = true, -- shows your registers on " in NORMAL or <C-r> in INSERT mode
+      -- Format function for register values. Accepts a string and returns a formatted string.
+      -- Useful for truncating long register contents to prevent UI freezing.
+      -- The default truncates at 100 characters to balance readability and performance.
+      ---@type fun(value: string): string
+      format = function(value)
+        local max_len = 100 -- Truncate after 100 characters to prevent UI freezing
+        if #value > max_len then
+          return value:sub(1, max_len) .. "…"
+        end
+        return value
+      end,
+    },
     -- the presets plugin, adds help for a bunch of default keybindings in Neovim
     -- No actual key bindings are created
     spelling = {


### PR DESCRIPTION
## Description

Add a format function to make contents can be truncated.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

